### PR TITLE
Korean Maps via Jamo

### DIFF
--- a/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
+++ b/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
@@ -74,6 +74,10 @@ tests:
     expected: "Hwangu"
   - source: 자작보
     expected: "Chajakpo"
+  - source: 비파1동
+    expected: "Pip’a Il-tong"
+  - source: 문암 오동
+    expected: "Munam O-dong"
 
 map:
   character_separator: ""
@@ -115,10 +119,6 @@ map:
       result: " "
     - pattern: "$"
       result: " "
-
-    # Onset Rule (두음법칙)
-    - pattern: "(^ᄅ| ᄅ)(?=[ᅣᅧᅨᅭᅲᅵ])" #CHOSEONG RIEUL
-      result: "ᄋ" #CHOSEONG IEUNG
 
     # From Unicode Chart
     # https://github.com/unicode-org/cldr/blob/master/common/transforms/Korean-Latin-BGN.xml
@@ -542,53 +542,53 @@ map:
       result: "p\\1ss" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGSIOS
     - pattern: "ᆲ(-?)ᄍ"
       result: "p\\1tch" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGCIEUC
-    - pattern: "(^ᄀ| ᄀ)"
+    - pattern: "(?<= )ᄀ"
       result: "k" # HANGUL CHOSEONG KIYEOK
-    - pattern: "(^ᄂ| ᄂ)"
+    - pattern: "(?<= )ᄂ"
       result: "n" # HANGUL CHOSEONG NIEUN
-    - pattern: "(^ᄃ| ᄃ)"
+    - pattern: "(?<= )ᄃ"
       result: "t" # HANGUL CHOSEONG TIKEUT
-    - pattern: "(^ᄅ| ᄅ)(?=[ᅣᅤᅧᅨᅭᅲ])"
+    - pattern: "(?<= )ᄅ(?=[ᅣᅤᅧᅨᅭᅲ])"
       result: "" # HANGUL CHOSEONG RIEUL # R-onset rule
-    - pattern: "(^ᄅ| ᄅ)"
+    - pattern: "(?<= )ᄅ"
       result: "n" # HANGUL CHOSEONG RIEUL
-    - pattern: "(^ᄆ| ᄆ)"
+    - pattern: "(?<= )ᄆ"
       result: "m" # HANGUL CHOSEONG MIEUM
-    - pattern: "(^ᄇ| ᄇ)"
+    - pattern: "(?<= )ᄇ"
       result: "p" # HANGUL CHOSEONG PIEUP
-    - pattern: "(^ᄉ| ᄉ)"
+    - pattern: "(?<= )ᄉ"
       result: "s" # HANGUL CHOSEONG SIOS
-    - pattern: "(^ᄋ| ᄋ)"
+    - pattern: "(?<= )ᄋ"
       result: "" # HANGUL CHOSEONG IEUNG
-    - pattern: "(^ᄌ| ᄌ)"
+    - pattern: "(?<= )ᄌ"
       result: "ch" # HANGUL CHOSEONG CIEUC
-    - pattern: "(^ᄎ| ᄎ)"
+    - pattern: "(?<= )ᄎ"
       result: "ch’" # HANGUL CHOSEONG CHIEUCH
-    - pattern: "(^ᄏ| ᄏ)"
+    - pattern: "(?<= )ᄏ"
       result: "k’" # HANGUL CHOSEONG KHIEUKH
-    - pattern: "(^ᄐ| ᄐ)"
+    - pattern: "(?<= )ᄐ"
       result: "t’" # HANGUL CHOSEONG THIEUTH
-    - pattern: "(^ᄑ| ᄑ)"
+    - pattern: "(?<= )ᄑ"
       result: "p’" # HANGUL CHOSEONG PHIEUPH
-    - pattern: "(^ᄒ| ᄒ)"
+    - pattern: "(?<= )ᄒ"
       result: "h" # HANGUL CHOSEONG HIEUH
-    - pattern: "(^ᄁ| ᄁ)"
+    - pattern: "(?<= )ᄁ"
       result: "kk" # HANGUL CHOSEONG SSANGKIYEOK
-    - pattern: "(^ᄭ| ᄭ)"
+    - pattern: "(?<= )ᄭ"
       result: "kk" # HANGUL CHOSEONG SIOS-KIYEOK
-    - pattern: "(^ᄄ| ᄄ)"
+    - pattern: "(?<= )ᄄ"
       result: "tt" # HANGUL CHOSEONG SSANGTIKEUT
-    - pattern: "(^ᄯ| ᄯ)"
+    - pattern: "(?<= )ᄯ"
       result: "tt" # HANGUL CHOSEONG SIOS-TIKEUT
-    - pattern: "(^ᄈ| ᄈ)"
+    - pattern: "(?<= )ᄈ"
       result: "pp" # HANGUL CHOSEONG SSANGPIEUP
-    - pattern: "(^ᄲ| ᄲ)"
+    - pattern: "(?<= )ᄲ"
       result: "pp" # HANGUL CHOSEONG SIOS-PIEUP
-    - pattern: "(^ᄊ| ᄊ)"
+    - pattern: "(?<= )ᄊ"
       result: "ss" # HANGUL CHOSEONG SSANGSIOS
-    - pattern: "(^ᄍ| ᄍ)"
+    - pattern: "(?<= )ᄍ"
       result: "tch" # HANGUL CHOSEONG SSANGCIEUC
-    - pattern: "(^ᄶ| ᄶ)"
+    - pattern: "(?<= )ᄶ"
       result: "tch" # HANGUL CHOSEONG SIOS-CIEUC
     - pattern: "ᅡ"
       result: "a" # HANGUL JUNGSEONG A
@@ -632,35 +632,35 @@ map:
       result: "wae" # HANGUL JUNGSEONG WAE
     - pattern: "ᅰ"
       result: "we" # HANGUL JUNGSEONG WE
-    - pattern: "(ᆨ$|ᆨ[ -])"
+    - pattern: "ᆨ(?=[ -])"
       result: "k" # HANGUL JONGSEONG KIYEOK
-    - pattern: "(ᆫ$|ᆫ[ -])"
+    - pattern: "ᆫ(?=[ -])"
       result: "n" # HANGUL JONGSEONG NIEUN
-    - pattern: "(ᆮ$|ᆮ[ -])"
+    - pattern: "ᆮ(?=[ -])"
       result: "t" # HANGUL JONGSEONG TIKEUT
-    - pattern: "(ᆯ$|ᆯ[ -])"
+    - pattern: "ᆯ(?=[ -])"
       result: "l" # HANGUL JONGSEONG RIEUL
-    - pattern: "(ᆷ$|ᆷ[ -])"
+    - pattern: "ᆷ(?=[ -])"
       result: "m" # HANGUL JONGSEONG MIEUM
-    - pattern: "(ᆸ$|ᆸ[ -])"
+    - pattern: "ᆸ(?=[ -])"
       result: "p" # HANGUL JONGSEONG PIEUP
-    - pattern: "(ᆺ$|ᆺ[ -])"
+    - pattern: "ᆺ(?=[ -])"
       result: "t" # HANGUL JONGSEONG SIOS
-    - pattern: "(ᆼ$|ᆼ[ -])"
+    - pattern: "ᆼ(?=[ -])"
       result: "ng" # HANGUL JONGSEONG IEUNG
-    - pattern: "(ᆽ$|ᆽ[ -])"
+    - pattern: "ᆽ(?=[ -])"
       result: "t" # HANGUL JONGSEONG CIEUC
-    - pattern: "(ᆾ$|ᆾ[ -])"
+    - pattern: "ᆾ(?=[ -])"
       result: "t" # HANGUL JONGSEONG CHIEUCH
-    - pattern: "(ᆿ$|ᆿ[ -])"
+    - pattern: "ᆿ(?=[ -])"
       result: "k" # HANGUL JONGSEONG KHIEUKH
-    - pattern: "(ᇀ$|ᇀ[ -])"
+    - pattern: "ᇀ(?=[ -])"
       result: "t" # HANGUL JONGSEONG THIEUTH
-    - pattern: "(ᇁ$|ᇁ[ -])"
+    - pattern: "ᇁ(?=[ -])"
       result: "p" # HANGUL JONGSEONG PHIEUPH
-    - pattern: "(ᆰ$|ᆰ[ -])"
+    - pattern: "ᆰ(?=[ -])"
       result: "k" # HANGUL JONGSEONG RIEUL-KIYEOK
-    - pattern: "(ᆲ$|ᆲ[ -])"
+    - pattern: "ᆲ(?=[ -])"
       result: "p" # HANGUL JONGSEONG RIEUL-PIEUP
 
     # Remove space added

--- a/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
+++ b/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
@@ -1,0 +1,673 @@
+---
+authority_id: bgn
+id: 1939
+language: kor
+source_script: Hang
+destination_script: Latn
+name: BGN Agreement -- Korean McCune-Reischauer System (1943)
+url: http://geonames.nga.mil/gns/html/Romanization/ROMANIZATION%20OF%20KOREAN-%20MR%20for%20DPRK.pdf
+creation_date: 1939
+adoption_date: 
+description:
+
+notes:
+  BGN/PCGN 1945 Agreement
+
+tests:
+  - source: 은하리
+    expected: "Ŭnha-ri"
+  - source: 은중리   
+    expected: "Ŭnjung-ni"
+  - source: 은장령
+    expected: "Ŭnjang-nyŏng"
+  - source: 은혜동
+    expected: "Ŭnhye-dong"
+  - source: 은호리
+    expected: "Ŭnho-ri"
+  - source: 은행정
+    expected: "Ŭnhaengjŏng"
+  - source: 은행동
+    expected: "Ŭnhaeng-dong"
+  - source: 은행촌
+    expected: "Ŭnhaeng-ch’on"
+  - source: 원수
+    expected: "Wŏnsu"
+  - source: 원소리고개
+    expected: "Wŏnsori-gogae"
+  - source: 원소참
+    expected: "Wŏnsoch’am"
+  - source: 원소리
+    expected: "Wŏnso-ri"
+  - source: 원신리
+    expected: "Wŏnsil-li"
+  - source: 난곡
+    expected: "Nan’gok"
+  - source: 난산리
+    expected: "Nansal-li"
+  - source: 난직
+    expected: "Nanjik"
+  - source: 영곡
+    expected: "Yŏnggok"
+  - source: 윗두밀
+    expected: "Wittumil"
+  - source: 윗도심이
+    expected: "Wittosimi"
+  - source: 둔지
+    expected: "Tunji"
+  - source: 서승
+    expected: "Sŏsŭng"
+  # - source: 신촌
+  #   expected: "Sinch’on"
+  - source: 비암덕
+    expected: "Piamdŏk"
+  - source: 바위안
+    expected: "Pawian"
+  - source: 오송평
+    expected: "Osongp’yŏng"
+  - source: 그물목
+    expected: "Kŭmulmok"
+  - source: 구원정
+    expected: "Kuwŏnjŏng"
+  - source: 일하
+    expected: "Irha"
+  - source: 황우
+    expected: "Hwangu"
+  - source: 자작보
+    expected: "Chajakpo"
+
+map:
+  character_separator: ""
+  word_separator: " "
+  title_case: True
+  extend: "nil-kor-Hang-Hang-jamo"
+
+  rules:
+    # convert numbers to space + Hangul
+    - pattern: "([^0-9 ])(?=[0-9])"
+      result: "\\1 "      
+    - pattern: "1"
+      result: "일"
+    - pattern: "2"
+      result: "이"
+    - pattern: "3"
+      result: "삼"
+    - pattern: "4"
+      result: "사"
+    - pattern: "5"
+      result: "오"
+    - pattern: "6"
+      result: "육"
+    - pattern: "7"
+      result: "칠"
+    - pattern: "8"
+      result: "팔"
+    - pattern: "9"
+      result: "구"
+
+    # add hyphen in front of generics
+    - pattern: "(?<=.)(구역|동|리|도|고개|골|로동자구|사무소|초등학교|중학교|고등학교|강|포|령|역|봉|사|천|교|제|저수지|소류지|재|못|말|면|암|교회|촌|병원|바위|공원|섬|우체국|대학교|보건소|굴|치|대교|지구|폭포|해수욕장|휴게소|중고교|읍|보건진료소|마을|톨게이트|대학|시장|경찰서|학교)$" #to be expanded
+      result: "-\\1"
+
+  postrules:
+
+    # Add space to the two ends of the string for easier word boundary handling
+    - pattern: "^"
+      result: " "
+    - pattern: "$"
+      result: " "
+
+    # Onset Rule (두음법칙)
+    - pattern: "(^ᄅ| ᄅ)(?=[ᅣᅧᅨᅭᅲᅵ])" #CHOSEONG RIEUL
+      result: "ᄋ" #CHOSEONG IEUNG
+
+    # From Unicode Chart
+    # https://github.com/unicode-org/cldr/blob/master/common/transforms/Korean-Latin-BGN.xml
+    - pattern: "ᆨ(-?)ᄀ"
+      result: "k\\1k" # HANGUL JONGSEONG KIYEOK + CHOSEONG KIYEOK
+    - pattern: "ᆨ(-?)ᄂ"
+      result: "ng\\1n" # HANGUL JONGSEONG KIYEOK + CHOSEONG NIEUN
+    - pattern: "ᆨ(-?)ᄃ"
+      result: "k\\1t" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIKEUT
+    - pattern: "ᆨ(-?)ᄅ"
+      result: "ng\\1n" # HANGUL JONGSEONG KIYEOK + CHOSEONG RIEUL
+    - pattern: "ᆨ(-?)ᄆ"
+      result: "ng\\1m" # HANGUL JONGSEONG KIYEOK + CHOSEONG MIEUM
+    - pattern: "ᆨ(-?)ᄇ"
+      result: "k\\1p" # HANGUL JONGSEONG KIYEOK + CHOSEONG PIEUP
+    - pattern: "ᆨ(-?)ᄉ"
+      result: "k\\1s" # HANGUL JONGSEONG KIYEOK + CHOSEONG SIOS
+    - pattern: "ᆨ(-?)ᄋ"
+      result: "g\\1" # HANGUL JONGSEONG KIYEOK + CHOSEONG IEUNG
+    - pattern: "ᆨ(-?)ᄌ"
+      result: "k\\1ch" # HANGUL JONGSEONG KIYEOK + CHOSEONG CIEUC
+    - pattern: "ᆨ(-?)ᄎ"
+      result: "k\\1ch’" # HANGUL JONGSEONG KIYEOK + CHOSEONG CHIEUCH
+    - pattern: "ᆨ(-?)ᄏ"
+      result: "k\\1k’" # HANGUL JONGSEONG KIYEOK + CHOSEONG KHIEUKH
+    - pattern: "ᆨ(-?)ᄐ"
+      result: "k\\1t’" # HANGUL JONGSEONG KIYEOK + CHOSEONG THIEUTH
+    - pattern: "ᆨ(-?)ᄑ"
+      result: "k\\1p’" # HANGUL JONGSEONG KIYEOK + CHOSEONG PHIEUPH
+    - pattern: "ᆨ(-?)ᄒ"
+      result: "k\\1h" # HANGUL JONGSEONG KIYEOK + CHOSEONG HIEUH
+    - pattern: "ᆨ(-?)ᄁ"
+      result: "k\\1k" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆨ(-?)ᄄ"
+      result: "k\\1tt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆨ(-?)ᄈ"
+      result: "k\\1pp" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGPIEUP
+    - pattern: "ᆨ(-?)ᄊ"
+      result: "k\\1ss" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGSIOS
+    - pattern: "ᆨ(-?)ᄍ"
+      result: "k\\1tch" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGCIEUC
+    - pattern: "ᆫᄀ"
+      result: "n’g" # HANGUL JONGSEONG NIEUN + CHOSEONG KIEUK
+    - pattern: "ᆫ(-)ᄀ"
+      result: "n\\1g" # HANGUL JONGSEONG NIEUN + CHOSEONG KIEUK
+    - pattern: "ᆫ(-?)ᄂ"
+      result: "n\\1n" # HANGUL JONGSEONG NIEUN + CHOSEONG NIEUN
+    - pattern: "ᆫ(-?)ᄃ"
+      result: "n\\1d" # HANGUL JONGSEONG NIEUN + CHOSEONG TIKEUT
+    - pattern: "ᆫ(-?)ᄅ"
+      result: "l\\1l" # HANGUL JONGSEONG NIEUN + CHOSEONG RIEUL
+    - pattern: "ᆫ(-?)ᄆ"
+      result: "n\\1m" # HANGUL JONGSEONG NIEUN + CHOSEONG MIEUM
+    - pattern: "ᆫ(-?)ᄇ"
+      result: "n\\1b" # HANGUL JONGSEONG NIEUN + CHOSEONG PIEUP
+    - pattern: "ᆫ(-?)ᄉ"
+      result: "n\\1s" # HANGUL JONGSEONG NIEUN + CHOSEONG SIOS
+    - pattern: "ᆫ(-?)ᄋ"
+      result: "n\\1" # HANGUL JONGSEONG NIEUN + CHOSEONG IEUNG
+    - pattern: "ᆫ(-?)ᄌ"
+      result: "n\\1j" # HANGUL JONGSEONG NIEUN + CHOSEONG CIEUC
+    - pattern: "ᆫ(-?)ᄎ"
+      result: "n\\1ch’" # HANGUL JONGSEONG NIEUN + CHOSEONG CHIEUCH
+    - pattern: "ᆫ(-?)ᄏ"
+      result: "n\\1k’" # HANGUL JONGSEONG NIEUN + CHOSEONG KHIEUKH
+    - pattern: "ᆫ(-?)ᄐ"
+      result: "n\\1t’" # HANGUL JONGSEONG NIEUN + CHOSEONG THIEUTH
+    - pattern: "ᆫ(-?)ᄑ"
+      result: "n\\1p’" # HANGUL JONGSEONG NIEUN + CHOSEONG PHIEUPH
+    - pattern: "ᆫ(-?)ᄒ"
+      result: "n\\1h" # HANGUL JONGSEONG NIEUN + CHOSEONG HIEUH
+    - pattern: "ᆫ(-?)ᄁ"
+      result: "n\\1kk" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆫ(-?)ᄄ"
+      result: "n\\1tt" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆫ(-?)ᄈ"
+      result: "n\\1pp" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGPIEUP
+    - pattern: "ᆫ(-?)ᄊ"
+      result: "n\\1ss" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGSIOS
+    - pattern: "ᆫ(-?)ᄍ"
+      result: "n\\1tch" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGCIEUC
+    - pattern: "ᆯ(-?)ᄀ"
+      result: "l\\1g" # HANGUL JONGSEONG RIEUL + CHOSEONG KIYEOK
+    - pattern: "ᆯ(-?)ᄂ"
+      result: "l\\1l" # HANGUL JONGSEONG RIEUL + CHOSEONG NIEUN
+    - pattern: "ᆯ(-?)ᄃ"
+      result: "l\\1t" # HANGUL JONGSEONG RIEUL + CHOSEONG TIKEUT
+    - pattern: "ᆯ(-?)ᄅ"
+      result: "l\\1l" # HANGUL JONGSEONG RIEUL + CHOSEONG RIEUL
+    - pattern: "ᆯ(-?)ᄆ"
+      result: "l\\1m" # HANGUL JONGSEONG RIEUL + CHOSEONG MIEUM
+    - pattern: "ᆯ(-?)ᄇ"
+      result: "l\\1b" # HANGUL JONGSEONG RIEUL + CHOSEONG PIEUP
+    - pattern: "ᆯ(-?)ᄉ"
+      result: "l\\1s" # HANGUL JONGSEONG RIEUL + CHOSEONG SIOS
+    - pattern: "ᆯ(-?)ᄋ"
+      result: "r\\1" # HANGUL JONGSEONG RIEUL + CHOSEONG IEUNG
+    - pattern: "ᆯ(-?)ᄌ"
+      result: "l\\1ch" # HANGUL JONGSEONG RIEUL + CHOSEONG CIEUC
+    - pattern: "ᆯ(-?)ᄎ"
+      result: "l\\1ch’" # HANGUL JONGSEONG RIEUL + CHOSEONG CHIEUCH
+    - pattern: "ᆯ(-?)ᄏ"
+      result: "l\\1k’" # HANGUL JONGSEONG RIEUL + CHOSEONG KHIEUKH
+    - pattern: "ᆯ(-?)ᄐ"
+      result: "l\\1t’" # HANGUL JONGSEONG RIEUL + CHOSEONG THIEUTH
+    - pattern: "ᆯ(-?)ᄑ"
+      result: "l\\1p’" # HANGUL JONGSEONG RIEUL + CHOSEONG PHIEUPH
+    - pattern: "ᆯ(-?)ᄒ"
+      result: "r\\1h" # HANGUL JONGSEONG RIEUL + CHOSEONG HIEUH
+    - pattern: "ᆯ(-?)ᄁ"
+      result: "l\\1kk" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆯ(-?)ᄄ"
+      result: "l\\1tt" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆯ(-?)ᄈ"
+      result: "l\\1pp" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGPIEUP
+    - pattern: "ᆯ(-?)ᄊ"
+      result: "l\\1ss" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGSIOS
+    - pattern: "ᆯ(-?)ᄍ"
+      result: "l\\1tch" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGCIEUC
+    - pattern: "ᆷ(-?)ᄀ"
+      result: "m\\1g" # HANGUL JONGSEONG MIEUM + CHOSEONG KIYEOK
+    - pattern: "ᆷ(-?)ᄂ"
+      result: "m\\1n" # HANGUL JONGSEONG MIEUM + CHOSEONG NIEUN
+    - pattern: "ᆷ(-?)ᄃ"
+      result: "m\\1d" # HANGUL JONGSEONG MIEUM + CHOSEONG TIKEUT
+    - pattern: "ᆷ(-?)ᄅ"
+      result: "m\\1n" # HANGUL JONGSEONG MIEUM + CHOSEONG RIEUL
+    - pattern: "ᆷ(-?)ᄆ"
+      result: "m\\1m" # HANGUL JONGSEONG MIEUM + CHOSEONG MIEUM
+    - pattern: "ᆷ(-?)ᄇ"
+      result: "m\\1b" # HANGUL JONGSEONG MIEUM + CHOSEONG PIEUP
+    - pattern: "ᆷ(-?)ᄉ"
+      result: "m\\1s" # HANGUL JONGSEONG MIEUM + CHOSEONG SIOS
+    - pattern: "ᆷ(-?)ᄋ"
+      result: "m\\1" # HANGUL JONGSEONG MIEUM + CHOSEONG IEUNG
+    - pattern: "ᆷ(-?)ᄌ"
+      result: "m\\1j" # HANGUL JONGSEONG MIEUM + CHOSEONG CIEUC
+    - pattern: "ᆷ(-?)ᄎ"
+      result: "m\\1ch’" # HANGUL JONGSEONG MIEUM + CHOSEONG CHIEUCH
+    - pattern: "ᆷ(-?)ᄏ"
+      result: "m\\1k’" # HANGUL JONGSEONG MIEUM + CHOSEONG KHIEUKH
+    - pattern: "ᆷ(-?)ᄐ"
+      result: "m\\1t’" # HANGUL JONGSEONG MIEUM + CHOSEONG THIEUTH
+    - pattern: "ᆷ(-?)ᄑ"
+      result: "m\\1p’" # HANGUL JONGSEONG MIEUM + CHOSEONG PHIEUPH
+    - pattern: "ᆷ(-?)ᄒ"
+      result: "m\\1h" # HANGUL JONGSEONG MIEUM + CHOSEONG HIEUH
+    - pattern: "ᆷ(-?)ᄁ"
+      result: "m\\1kk" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆷ(-?)ᄄ"
+      result: "m\\1tt" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆷ(-?)ᄈ"
+      result: "m\\1pp" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGPIEUP
+    - pattern: "ᆷ(-?)ᄊ"
+      result: "m\\1ss" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGSIOS
+    - pattern: "ᆷ(-?)ᄍ"
+      result: "m\\1tch" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGCIEUC
+    - pattern: "ᆸ(-?)ᄀ"
+      result: "p\\1k" # HANGUL JONGSEONG PIEUP + CHOSEONG KIYEOK
+    - pattern: "ᆸ(-?)ᄂ"
+      result: "m\\1n" # HANGUL JONGSEONG PIEUP + CHOSEONG NIEUN
+    - pattern: "ᆸ(-?)ᄃ"
+      result: "p\\1t" # HANGUL JONGSEONG PIEUP + CHOSEONG TIKEUT
+    - pattern: "ᆸ(-?)ᄅ"
+      result: "m\\1n" # HANGUL JONGSEONG PIEUP + CHOSEONG RIEUL
+    - pattern: "ᆸ(-?)ᄆ"
+      result: "m\\1m" # HANGUL JONGSEONG PIEUP + CHOSEONG MIEUM
+    - pattern: "ᆸ(-?)ᄇ"
+      result: "p\\1p" # HANGUL JONGSEONG PIEUP + CHOSEONG PIEUP
+    - pattern: "ᆸ(-?)ᄉ"
+      result: "p\\1s" # HANGUL JONGSEONG PIEUP + CHOSEONG SIOS
+    - pattern: "ᆸ(-?)ᄋ"
+      result: "p\\1" # HANGUL JONGSEONG PIEUP + CHOSEONG IEUNG
+    - pattern: "ᆸ(-?)ᄌ"
+      result: "p\\1ch" # HANGUL JONGSEONG PIEUP + CHOSEONG CIEUC
+    - pattern: "ᆸ(-?)ᄎ"
+      result: "p\\1ch’" # HANGUL JONGSEONG PIEUP + CHOSEONG CHIEUCH
+    - pattern: "ᆸ(-?)ᄏ"
+      result: "p\\1k’" # HANGUL JONGSEONG PIEUP + CHOSEONG KHIEUKH
+    - pattern: "ᆸ(-?)ᄐ"
+      result: "p\\1t’" # HANGUL JONGSEONG PIEUP + CHOSEONG THIEUTH
+    - pattern: "ᆸ(-?)ᄑ"
+      result: "p\\1p’" # HANGUL JONGSEONG PIEUP + CHOSEONG PHIEUPH
+    - pattern: "ᆸ(-?)ᄒ"
+      result: "p\\1h" # HANGUL JONGSEONG PIEUP + CHOSEONG HIEUH
+    - pattern: "ᆸ(-?)ᄁ"
+      result: "p\\1kk" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆸ(-?)ᄄ"
+      result: "p\\1tt" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆸ(-?)ᄈ"
+      result: "p\\1p" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGPIEUP
+    - pattern: "ᆸ(-?)ᄊ"
+      result: "p\\1ss" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGSIOS
+    - pattern: "ᆸ(-?)ᄍ"
+      result: "p\\1tch" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGCIEUC
+    - pattern: "ᆺ(-?)ᄀ"
+      result: "k\\1k" # HANGUL JONGSEONG SIOS + CHOSEONG KIYEOK
+    - pattern: "ᆺ(-?)ᄂ"
+      result: "n\\1n" # HANGUL JONGSEONG SIOS + CHOSEONG NIEUN
+    - pattern: "ᆺ(-?)ᄃ"
+      result: "t\\1t" # HANGUL JONGSEONG SIOS + CHOSEONG TIKEUT
+    - pattern: "ᆺ(-?)ᄅ"
+      result: "n\\1n" # HANGUL JONGSEONG SIOS + CHOSEONG RIEUL
+    - pattern: "ᆺ(-?)ᄆ"
+      result: "n\\1m" # HANGUL JONGSEONG SIOS + CHOSEONG MIEUM
+    - pattern: "ᆺ(-?)ᄇ"
+      result: "p\\1p" # HANGUL JONGSEONG SIOS + CHOSEONG PIEUP
+    - pattern: "ᆺ(-?)ᄉ"
+      result: "s\\1s" # HANGUL JONGSEONG SIOS + CHOSEONG SIOS
+    - pattern: "ᆺ(-?)ᄋ"
+      result: "d\\1" # HANGUL JONGSEONG SIOS + CHOSEONG IEUNG
+    - pattern: "ᆺ(-?)ᄌ"
+      result: "t\\1ch" # HANGUL JONGSEONG SIOS + CHOSEONG CIEUC
+    - pattern: "ᆺ(-?)ᄎ"
+      result: "t\\1ch’" # HANGUL JONGSEONG SIOS + CHOSEONG CHIEUCH
+    - pattern: "ᆺ(-?)ᄏ"
+      result: "t\\1k’" # HANGUL JONGSEONG SIOS + CHOSEONG KHIEUKH
+    - pattern: "ᆺ(-?)ᄐ"
+      result: "t\\1t’" # HANGUL JONGSEONG SIOS + CHOSEONG THIEUTH
+    - pattern: "ᆺ(-?)ᄑ"
+      result: "t\\1p’" # HANGUL JONGSEONG SIOS + CHOSEONG PHIEUPH
+    - pattern: "ᆺ(-?)ᄒ"
+      result: "t\\1h" # HANGUL JONGSEONG SIOS + CHOSEONG HIEUH
+    - pattern: "ᆺ(-?)ᄁ"
+      result: "t\\1kk" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆺ(-?)ᄄ"
+      result: "t\\1t" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆺ(-?)ᄈ"
+      result: "t\\1pp" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGPIEUP
+    - pattern: "ᆺ(-?)ᄊ"
+      result: "t\\1ss" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGSIOS
+    - pattern: "ᆺ(-?)ᄍ"
+      result: "t\\1ch" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGCIEUC
+    - pattern: "ᆼ(-?)ᄀ"
+      result: "ng\\1g" # HANGUL JONGSEONG IEUNG + CHOSEONG KIYEOK
+    - pattern: "ᆼ(-?)ᄂ"
+      result: "ng\\1n" # HANGUL JONGSEONG IEUNG + CHOSEONG NIEUN
+    - pattern: "ᆼ(-?)ᄃ"
+      result: "ng\\1d" # HANGUL JONGSEONG IEUNG + CHOSEONG TIKEUT
+    - pattern: "ᆼ(-?)ᄅ"
+      result: "ng\\1n" # HANGUL JONGSEONG IEUNG + CHOSEONG RIEUL
+    - pattern: "ᆼ(-?)ᄆ"
+      result: "ng\\1m" # HANGUL JONGSEONG IEUNG + CHOSEONG MIEUM
+    - pattern: "ᆼ(-?)ᄇ"
+      result: "ng\\1b" # HANGUL JONGSEONG IEUNG + CHOSEONG PIEUP
+    - pattern: "ᆼ(-?)ᄉ"
+      result: "ng\\1s" # HANGUL JONGSEONG IEUNG + CHOSEONG SIOS
+    - pattern: "ᆼ(-?)ᄋ"
+      result: "ng\\1" # HANGUL JONGSEONG IEUNG + CHOSEONG IEUNG
+    - pattern: "ᆼ(-?)ᄌ"
+      result: "ng\\1j" # HANGUL JONGSEONG IEUNG + CHOSEONG CIEUC
+    - pattern: "ᆼ(-?)ᄎ"
+      result: "ng\\1ch’" # HANGUL JONGSEONG IEUNG + CHOSEONG CHIEUCH
+    - pattern: "ᆼ(-?)ᄏ"
+      result: "ng\\1k’" # HANGUL JONGSEONG IEUNG + CHOSEONG KHIEUKH
+    - pattern: "ᆼ(-?)ᄐ"
+      result: "ng\\1t’" # HANGUL JONGSEONG IEUNG + CHOSEONG THIEUTH
+    - pattern: "ᆼ(-?)ᄑ"
+      result: "ng\\1p’" # HANGUL JONGSEONG IEUNG + CHOSEONG PHIEUPH
+    - pattern: "ᆼ(-?)ᄒ"
+      result: "ng\\1h" # HANGUL JONGSEONG IEUNG + CHOSEONG HIEUH
+    - pattern: "ᆼ(-?)ᄁ"
+      result: "ng\\1kk" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆼ(-?)ᄄ"
+      result: "ng\\1tt" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆼ(-?)ᄈ"
+      result: "ng\\1pp" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGPIEUP
+    - pattern: "ᆼ(-?)ᄊ"
+      result: "ng\\1ss" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGSIOS
+    - pattern: "ᆼ(-?)ᄍ"
+      result: "ng\\1tch" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGCIEUC
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄀ"
+      result: "\\1g" # HANGUL JONGSEONG KIYEOK + CHOSEONG KIYEOK
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄂ"
+      result: "\\1n" # HANGUL JONGSEONG KIYEOK + CHOSEONG NIEUN
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄃ"
+      result: "\\1d" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIKEUT
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄅ"
+      result: "\\1r" # HANGUL JONGSEONG KIYEOK + CHOSEONG RIEUL
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄆ"
+      result: "\\1m" # HANGUL JONGSEONG KIYEOK + CHOSEONG MIEUM
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄇ"
+      result: "\\1b" # HANGUL JONGSEONG KIYEOK + CHOSEONG PIEUP
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄉ"
+      result: "\\1s" # HANGUL JONGSEONG KIYEOK + CHOSEONG SIOS
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄋ"
+      result: "\\1" # HANGUL JONGSEONG KIYEOK + CHOSEONG IEUNG
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄌ"
+      result: "\\1j" # HANGUL JONGSEONG KIYEOK + CHOSEONG CIEUC
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄎ"
+      result: "\\1ch’" # HANGUL JONGSEONG KIYEOK + CHOSEONG CHIEUCH
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄏ"
+      result: "\\1k’" # HANGUL JONGSEONG KIYEOK + CHOSEONG KHIEUKH
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄐ"
+      result: "\\1t’" # HANGUL JONGSEONG KIYEOK + CHOSEONG THIEUTH
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄑ"
+      result: "\\1p’" # HANGUL JONGSEONG KIYEOK + CHOSEONG PHIEUPH
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄒ"
+      result: "\\1h" # HANGUL JONGSEONG KIYEOK + CHOSEONG HIEUH
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄁ"
+      result: "\\1kk" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGKIYEOK
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄄ"
+      result: "\\1tt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIKEUT
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄈ"
+      result: "\\1pp" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGPIEUP
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄊ"
+      result: "\\1ss" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGSIOS
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄍ"
+      result: "\\1tch" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGCIEUC
+    - pattern: "ᆰ(-?)ᄀ"
+      result: "l\\1g" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG KIYEOK
+    - pattern: "ᆰ(-?)ᄂ"
+      result: "ng\\1n" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG NIEUN
+    - pattern: "ᆰ(-?)ᄃ"
+      result: "k\\1t" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG TIKEUT
+    - pattern: "ᆰ(-?)ᄅ"
+      result: "ng\\1l" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG RIEUL
+    - pattern: "ᆰ(-?)ᄆ"
+      result: "ng\\1m" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG MIEUM
+    - pattern: "ᆰ(-?)ᄇ"
+      result: "k\\1p" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG PIEUP
+    - pattern: "ᆰ(-?)ᄉ"
+      result: "k\\1s" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SIOS
+    - pattern: "ᆰ(-?)ᄋ"
+      result: "l\\1g" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG IEUNG
+    - pattern: "ᆰ(-?)ᄌ"
+      result: "k\\1ch" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG CIEUC
+    - pattern: "ᆰ(-?)ᄎ"
+      result: "k\\1ch’" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG CHIEUCH
+    - pattern: "ᆰ(-?)ᄏ"
+      result: "l\\1k’" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG KHIEUKH
+    - pattern: "ᆰ(-?)ᄐ"
+      result: "k\\1t’" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG THIEUTH
+    - pattern: "ᆰ(-?)ᄑ"
+      result: "k\\1p’" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG PHIEUPH
+    - pattern: "ᆰ(-?)ᄒ"
+      result: "lk\\1h" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG HIEUH
+    - pattern: "ᆰ(-?)ᄁ"
+      result: "l\\1kk" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆰ(-?)ᄄ"
+      result: "k\\1tt" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆰ(-?)ᄈ"
+      result: "k\\1pp" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGPIEUP
+    - pattern: "ᆰ(-?)ᄊ"
+      result: "k\\1ss" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGSIOS
+    - pattern: "ᆰ(-?)ᄍ"
+      result: "k\\1tch" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGCIEUC
+    - pattern: "ᆱ(-?)ᄀ"
+      result: "m\\1g" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG KIYEOK
+    - pattern: "ᆱ(-?)ᄂ"
+      result: "m\\1n" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG NIEUN
+    - pattern: "ᆱ(-?)ᄃ"
+      result: "m\\1d" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG TIKEUT
+    - pattern: "ᆱ(-?)ᄅ"
+      result: "m\\1l" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG RIEUL
+    - pattern: "ᆱ(-?)ᄆ"
+      result: "l\\1m" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG MIEUM
+    - pattern: "ᆱ(-?)ᄇ"
+      result: "m\\1b" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG PIEUP
+    - pattern: "ᆱ(-?)ᄉ"
+      result: "m\\1s" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SIOS
+    - pattern: "ᆱ(-?)ᄋ"
+      result: "lm\\1" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG IEUNG
+    - pattern: "ᆱ(-?)ᄌ"
+      result: "m\\1j" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG CIEUC
+    - pattern: "ᆱ(-?)ᄎ"
+      result: "m\\1ch’" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG CHIEUCH
+    - pattern: "ᆱ(-?)ᄏ"
+      result: "m\\1k’" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG KHIEUKH
+    - pattern: "ᆱ(-?)ᄐ"
+      result: "m\\1t’" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG THIEUTH
+    - pattern: "ᆱ(-?)ᄑ"
+      result: "m\\1p’" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG PHIEUPH
+    - pattern: "ᆱ(-?)ᄒ"
+      result: "m\\1h" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG HIEUH
+    - pattern: "ᆱ(-?)ᄁ"
+      result: "m\\1kk" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆱ(-?)ᄄ"
+      result: "m\\1tt" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆱ(-?)ᄈ"
+      result: "m\\1pp" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGPIEUP
+    - pattern: "ᆱ(-?)ᄊ"
+      result: "m\\1ss" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGSIOS
+    - pattern: "ᆱ(-?)ᄍ"
+      result: "m\\1tch" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGCIEUC
+    - pattern: "ᆲ(-?)ᄀ"
+      result: "pk" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG KIYEOK
+    - pattern: "ᆲ(-?)ᄂ"
+      result: "mn" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG NIEUN
+    - pattern: "ᆲ(-?)ᄃ"
+      result: "p\\1t" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG TIKEUT
+    - pattern: "ᆲ(-?)ᄅ"
+      result: "m\\1l" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG RIEUL
+    - pattern: "ᆲ(-?)ᄆ"
+      result: "m\\1m" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG MIEUM
+    - pattern: "ᆲ(-?)ᄇ"
+      result: "l\\1b" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG PIEUP
+    - pattern: "ᆲ(-?)ᄉ"
+      result: "p\\1s" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SIOS
+    - pattern: "ᆲ(-?)ᄋ"
+      result: "lb\\1" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG IEUNG
+    - pattern: "ᆲ(-?)ᄌ"
+      result: "p\\1ch" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG CIEUC
+    - pattern: "ᆲ(-?)ᄎ"
+      result: "p\\1ch’" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG CHIEUCH
+    - pattern: "ᆲ(-?)ᄏ"
+      result: "p\\1k’" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG KHIEUKH
+    - pattern: "ᆲ(-?)ᄐ"
+      result: "p\\1t’" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG THIEUTH
+    - pattern: "ᆲ(-?)ᄑ"
+      result: "l\\1p’" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG PHIEUPH
+    - pattern: "ᆲ(-?)ᄒ"
+      result: "lp\\1h" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG HIEUH
+    - pattern: "ᆲ(-?)ᄁ"
+      result: "p\\1kk" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆲ(-?)ᄄ"
+      result: "p\\1tt" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆲ(-?)ᄈ"
+      result: "l\\1pp" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGPIEUP
+    - pattern: "ᆲ(-?)ᄊ"
+      result: "p\\1ss" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGSIOS
+    - pattern: "ᆲ(-?)ᄍ"
+      result: "p\\1tch" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGCIEUC
+    - pattern: "(^ᄀ| ᄀ)"
+      result: "k" # HANGUL CHOSEONG KIYEOK
+    - pattern: "(^ᄂ| ᄂ)"
+      result: "n" # HANGUL CHOSEONG NIEUN
+    - pattern: "(^ᄃ| ᄃ)"
+      result: "t" # HANGUL CHOSEONG TIKEUT
+    - pattern: "(^ᄅ| ᄅ)(?=[ᅣᅤᅧᅨᅭᅲ])"
+      result: "" # HANGUL CHOSEONG RIEUL # R-onset rule
+    - pattern: "(^ᄅ| ᄅ)"
+      result: "n" # HANGUL CHOSEONG RIEUL
+    - pattern: "(^ᄆ| ᄆ)"
+      result: "m" # HANGUL CHOSEONG MIEUM
+    - pattern: "(^ᄇ| ᄇ)"
+      result: "p" # HANGUL CHOSEONG PIEUP
+    - pattern: "(^ᄉ| ᄉ)"
+      result: "s" # HANGUL CHOSEONG SIOS
+    - pattern: "(^ᄋ| ᄋ)"
+      result: "" # HANGUL CHOSEONG IEUNG
+    - pattern: "(^ᄌ| ᄌ)"
+      result: "ch" # HANGUL CHOSEONG CIEUC
+    - pattern: "(^ᄎ| ᄎ)"
+      result: "ch’" # HANGUL CHOSEONG CHIEUCH
+    - pattern: "(^ᄏ| ᄏ)"
+      result: "k’" # HANGUL CHOSEONG KHIEUKH
+    - pattern: "(^ᄐ| ᄐ)"
+      result: "t’" # HANGUL CHOSEONG THIEUTH
+    - pattern: "(^ᄑ| ᄑ)"
+      result: "p’" # HANGUL CHOSEONG PHIEUPH
+    - pattern: "(^ᄒ| ᄒ)"
+      result: "h" # HANGUL CHOSEONG HIEUH
+    - pattern: "(^ᄁ| ᄁ)"
+      result: "kk" # HANGUL CHOSEONG SSANGKIYEOK
+    - pattern: "(^ᄭ| ᄭ)"
+      result: "kk" # HANGUL CHOSEONG SIOS-KIYEOK
+    - pattern: "(^ᄄ| ᄄ)"
+      result: "tt" # HANGUL CHOSEONG SSANGTIKEUT
+    - pattern: "(^ᄯ| ᄯ)"
+      result: "tt" # HANGUL CHOSEONG SIOS-TIKEUT
+    - pattern: "(^ᄈ| ᄈ)"
+      result: "pp" # HANGUL CHOSEONG SSANGPIEUP
+    - pattern: "(^ᄲ| ᄲ)"
+      result: "pp" # HANGUL CHOSEONG SIOS-PIEUP
+    - pattern: "(^ᄊ| ᄊ)"
+      result: "ss" # HANGUL CHOSEONG SSANGSIOS
+    - pattern: "(^ᄍ| ᄍ)"
+      result: "tch" # HANGUL CHOSEONG SSANGCIEUC
+    - pattern: "(^ᄶ| ᄶ)"
+      result: "tch" # HANGUL CHOSEONG SIOS-CIEUC
+    - pattern: "ᅡ"
+      result: "a" # HANGUL JUNGSEONG A
+    - pattern: "ᅣ"
+      result: "ya" # HANGUL JUNGSEONG YA
+    - pattern: "ᅥ"
+      result: "ŏ" # HANGUL JUNGSEONG EO
+    - pattern: "ᅧ"
+      result: "yŏ" # HANGUL JUNGSEONG YEO
+    - pattern: "ᅩ"
+      result: "o" # HANGUL JUNGSEONG O
+    - pattern: "ᅭ"
+      result: "yo" # HANGUL JUNGSEONG YO
+    - pattern: "ᅮ"
+      result: "u" # HANGUL JUNGSEONG U
+    - pattern: "ᅲ"
+      result: "yu" # HANGUL JUNGSEONG YU
+    - pattern: "ᅳ"
+      result: "ŭ" # HANGUL JUNGSEONG EU
+    - pattern: "ᅵ"
+      result: "i" # HANGUL JUNGSEONG I
+    - pattern: "ᅢ"
+      result: "ae" # HANGUL JUNGSEONG AE
+    - pattern: "ᅤ"
+      result: "yae" # HANGUL JUNGSEONG YAE
+    - pattern: "ᅦ"
+      result: "e" # HANGUL JUNGSEONG E
+    - pattern: "ᅨ"
+      result: "ye" # HANGUL JUNGSEONG YE
+    - pattern: "ᅬ"
+      result: "oe" # HANGUL JUNGSEONG OE
+    - pattern: "ᅱ"
+      result: "wi" # HANGUL JUNGSEONG WI
+    - pattern: "ᅴ"
+      result: "ŭi" # HANGUL JUNGSEONG YI
+    - pattern: "ᅪ"
+      result: "wa" # HANGUL JUNGSEONG WA
+    - pattern: "ᅯ"
+      result: "wŏ" # HANGUL JUNGSEONG WEO
+    - pattern: "ᅫ"
+      result: "wae" # HANGUL JUNGSEONG WAE
+    - pattern: "ᅰ"
+      result: "we" # HANGUL JUNGSEONG WE
+    - pattern: "(ᆨ$|ᆨ[ -])"
+      result: "k" # HANGUL JONGSEONG KIYEOK
+    - pattern: "(ᆫ$|ᆫ[ -])"
+      result: "n" # HANGUL JONGSEONG NIEUN
+    - pattern: "(ᆮ$|ᆮ[ -])"
+      result: "t" # HANGUL JONGSEONG TIKEUT
+    - pattern: "(ᆯ$|ᆯ[ -])"
+      result: "l" # HANGUL JONGSEONG RIEUL
+    - pattern: "(ᆷ$|ᆷ[ -])"
+      result: "m" # HANGUL JONGSEONG MIEUM
+    - pattern: "(ᆸ$|ᆸ[ -])"
+      result: "p" # HANGUL JONGSEONG PIEUP
+    - pattern: "(ᆺ$|ᆺ[ -])"
+      result: "t" # HANGUL JONGSEONG SIOS
+    - pattern: "(ᆼ$|ᆼ[ -])"
+      result: "ng" # HANGUL JONGSEONG IEUNG
+    - pattern: "(ᆽ$|ᆽ[ -])"
+      result: "t" # HANGUL JONGSEONG CIEUC
+    - pattern: "(ᆾ$|ᆾ[ -])"
+      result: "t" # HANGUL JONGSEONG CHIEUCH
+    - pattern: "(ᆿ$|ᆿ[ -])"
+      result: "k" # HANGUL JONGSEONG KHIEUKH
+    - pattern: "(ᇀ$|ᇀ[ -])"
+      result: "t" # HANGUL JONGSEONG THIEUTH
+    - pattern: "(ᇁ$|ᇁ[ -])"
+      result: "p" # HANGUL JONGSEONG PHIEUPH
+    - pattern: "(ᆰ$|ᆰ[ -])"
+      result: "k" # HANGUL JONGSEONG RIEUL-KIYEOK
+    - pattern: "(ᆲ$|ᆲ[ -])"
+      result: "p" # HANGUL JONGSEONG RIEUL-PIEUP
+
+    # Remove space added
+    - pattern: "^ "
+      result: ""
+    - pattern: " $"
+      result: ""
+
+  characters:
+  # This is based on Jamo

--- a/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
+++ b/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
@@ -435,7 +435,7 @@ map:
     - pattern: "ᆰ(-?)ᄃ"
       result: "k\\1t" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG TIKEUT
     - pattern: "ᆰ(-?)ᄅ"
-      result: "ng\\1l" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG RIEUL
+      result: "ng\\1n" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG RIEUL
     - pattern: "ᆰ(-?)ᄆ"
       result: "ng\\1m" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG MIEUM
     - pattern: "ᆰ(-?)ᄇ"
@@ -473,7 +473,7 @@ map:
     - pattern: "ᆱ(-?)ᄃ"
       result: "m\\1d" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG TIKEUT
     - pattern: "ᆱ(-?)ᄅ"
-      result: "m\\1l" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG RIEUL
+      result: "m\\1n" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG RIEUL
     - pattern: "ᆱ(-?)ᄆ"
       result: "l\\1m" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG MIEUM
     - pattern: "ᆱ(-?)ᄇ"
@@ -511,7 +511,7 @@ map:
     - pattern: "ᆲ(-?)ᄃ"
       result: "p\\1t" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG TIKEUT
     - pattern: "ᆲ(-?)ᄅ"
-      result: "m\\1l" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG RIEUL
+      result: "m\\1n" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG RIEUL
     - pattern: "ᆲ(-?)ᄆ"
       result: "m\\1m" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG MIEUM
     - pattern: "ᆲ(-?)ᄇ"

--- a/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
+++ b/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
@@ -1,0 +1,631 @@
+---
+authority_id: bgn
+id: 1939
+language: kor
+source_script: Hang
+destination_script: Latn
+name: BGN Agreement -- Korean McCune-Reischauer System (1943)
+url: http://geonames.nga.mil/gns/html/Romanization/ROMANIZATION%20OF%20KOREAN-%20MR%20for%20DPRK.pdf
+creation_date: 1939
+adoption_date: 
+description:
+
+notes:
+  BGN/PCGN 1945 Agreement
+
+tests:
+  - source: 불국사
+    expected: "Bulguksa"
+  - source: 묵호
+    expected: "Mukho"
+  - source: 울산
+    expected: "Ulsan"
+  - source: 독립문
+    expected: "Dongnimmun"
+  - source: 강남역
+    expected: "Gangnamyeok"
+  - source: 남산리
+    expected: "Namsan-ri" #Note: no assimilation for -ri even after nasals
+  - source: 내월리
+    expected: "Naewol-ri"
+  - source: 울릉군
+    expected: "Ulleung-gun"
+  - source: 설악산
+    expected: "Seoraksan"
+  - source: 삼죽면
+    expected: "Samjuk-myeon"
+  - source: 평리1동
+    expected: "Pyeongni Il-dong"
+  - source: 평리2동
+    expected: "Pyeongni I-dong"
+
+map:
+  character_separator: ""
+  word_separator: " "
+  title_case: True
+  extend: "nil-kor-Hang-Hang-jamo"
+
+  rules:
+    # convert numbers to space + Hangul
+    - pattern: "([^0-9 ])(?=[0-9])"
+      result: "\\1 "      
+    - pattern: "1"
+      result: "일"
+    - pattern: "2"
+      result: "이"
+    - pattern: "3"
+      result: "삼"
+    - pattern: "4"
+      result: "사"
+    - pattern: "5"
+      result: "오"
+    - pattern: "6"
+      result: "육"
+    - pattern: "7"
+      result: "칠"
+    - pattern: "8"
+      result: "팔"
+    - pattern: "9"
+      result: "구"
+
+    # add hyphen in front of generics
+    - pattern: "(?<=.)(도|시|군|구|읍|면|리|동|가)$" 
+      result: "-\\1"
+
+  postrules:
+
+    # Add space to the two ends of the string for easier word boundary handling
+    - pattern: "^"
+      result: " "
+    - pattern: "$"
+      result: " "
+
+    # From Unicode Chart
+    # https://github.com/unicode-org/cldr/blob/master/common/transforms/Korean-Latin-BGN.xml
+    - pattern: "ᆨᄀ"
+      result: "kg" # HANGUL JONGSEONG KIYEOK + CHOSEONG KIYEOK
+    - pattern: "ᆨᄂ"
+      result: "ngn" # HANGUL JONGSEONG KIYEOK + CHOSEONG NIEUN
+    - pattern: "ᆨᄃ"
+      result: "kd" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIKEUT
+    - pattern: "ᆨᄅ"
+      result: "ngn" # HANGUL JONGSEONG KIYEOK + CHOSEONG RIEUL
+    - pattern: "ᆨᄆ"
+      result: "ngm" # HANGUL JONGSEONG KIYEOK + CHOSEONG MIEUM
+    - pattern: "ᆨᄇ"
+      result: "kb" # HANGUL JONGSEONG KIYEOK + CHOSEONG PIEUP
+    - pattern: "ᆨᄉ"
+      result: "ks" # HANGUL JONGSEONG KIYEOK + CHOSEONG SIOS
+    - pattern: "ᆨᄋ"
+      result: "g" # HANGUL JONGSEONG KIYEOK + CHOSEONG IEUNG
+    - pattern: "ᆨᄌ"
+      result: "kj" # HANGUL JONGSEONG KIYEOK + CHOSEONG CIEUC
+    - pattern: "ᆨᄎ"
+      result: "kch" # HANGUL JONGSEONG KIYEOK + CHOSEONG CHIEUCH
+    - pattern: "ᆨᄏ"
+      result: "kk" # HANGUL JONGSEONG KIYEOK + CHOSEONG KHIEUKH # NOTE: the dash is always skipped
+    - pattern: "ᆨᄐ"
+      result: "kt’" # HANGUL JONGSEONG KIYEOK + CHOSEONG THIEUTH
+    - pattern: "ᆨᄑ"
+      result: "kp" # HANGUL JONGSEONG KIYEOK + CHOSEONG PHIEUPH
+    - pattern: "ᆨᄒ"
+      result: "kh" # HANGUL JONGSEONG KIYEOK + CHOSEONG HIEUH
+    - pattern: "ᆨᄁ"
+      result: "kkk" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆨᄄ"
+      result: "ktt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆨᄈ"
+      result: "kpp" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGPIEUP
+    - pattern: "ᆨᄊ"
+      result: "kss" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGSIOS
+    - pattern: "ᆨᄍ"
+      result: "kjj" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGCIEUC
+    - pattern: "ᆫᄀ"
+      result: "ng" # HANGUL JONGSEONG NIEUN + CHOSEONG KIEUK
+    - pattern: "ᆫᄂ"
+      result: "nn" # HANGUL JONGSEONG NIEUN + CHOSEONG NIEUN
+    - pattern: "ᆫᄃ"
+      result: "nd" # HANGUL JONGSEONG NIEUN + CHOSEONG TIKEUT
+    - pattern: "ᆫᄅ"
+      result: "ll" # HANGUL JONGSEONG NIEUN + CHOSEONG RIEUL
+    - pattern: "ᆫᄆ"
+      result: "nm" # HANGUL JONGSEONG NIEUN + CHOSEONG MIEUM
+    - pattern: "ᆫᄇ"
+      result: "nb" # HANGUL JONGSEONG NIEUN + CHOSEONG PIEUP
+    - pattern: "ᆫᄉ"
+      result: "ns" # HANGUL JONGSEONG NIEUN + CHOSEONG SIOS
+    - pattern: "ᆫᄋ"
+      result: "n" # HANGUL JONGSEONG NIEUN + CHOSEONG IEUNG
+    - pattern: "ᆫᄌ"
+      result: "nj" # HANGUL JONGSEONG NIEUN + CHOSEONG CIEUC
+    - pattern: "ᆫᄎ"
+      result: "nch" # HANGUL JONGSEONG NIEUN + CHOSEONG CHIEUCH
+    - pattern: "ᆫᄏ"
+      result: "nk’" # HANGUL JONGSEONG NIEUN + CHOSEONG KHIEUKH
+    - pattern: "ᆫᄐ"
+      result: "nt" # HANGUL JONGSEONG NIEUN + CHOSEONG THIEUTH
+    - pattern: "ᆫᄑ"
+      result: "np" # HANGUL JONGSEONG NIEUN + CHOSEONG PHIEUPH
+    - pattern: "ᆫᄒ"
+      result: "nh" # HANGUL JONGSEONG NIEUN + CHOSEONG HIEUH
+    - pattern: "ᆫᄁ"
+      result: "nkk" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆫᄄ"
+      result: "ntt" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆫᄈ"
+      result: "npp" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGPIEUP
+    - pattern: "ᆫᄊ"
+      result: "nss" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGSIOS
+    - pattern: "ᆫᄍ"
+      result: "njj" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGCIEUC
+    - pattern: "ᆯᄀ"
+      result: "lg" # HANGUL JONGSEONG RIEUL + CHOSEONG KIYEOK
+    - pattern: "ᆯᄂ"
+      result: "ll" # HANGUL JONGSEONG RIEUL + CHOSEONG NIEUN
+    - pattern: "ᆯᄃ"
+      result: "ld" # HANGUL JONGSEONG RIEUL + CHOSEONG TIKEUT
+    - pattern: "ᆯᄅ"
+      result: "ll" # HANGUL JONGSEONG RIEUL + CHOSEONG RIEUL
+    - pattern: "ᆯᄆ"
+      result: "lm" # HANGUL JONGSEONG RIEUL + CHOSEONG MIEUM
+    - pattern: "ᆯᄇ"
+      result: "lb" # HANGUL JONGSEONG RIEUL + CHOSEONG PIEUP
+    - pattern: "ᆯᄉ"
+      result: "ls" # HANGUL JONGSEONG RIEUL + CHOSEONG SIOS
+    - pattern: "ᆯᄋ"
+      result: "r" # HANGUL JONGSEONG RIEUL + CHOSEONG IEUNG
+    - pattern: "ᆯᄌ"
+      result: "lj" # HANGUL JONGSEONG RIEUL + CHOSEONG CIEUC
+    - pattern: "ᆯᄎ"
+      result: "lch" # HANGUL JONGSEONG RIEUL + CHOSEONG CHIEUCH
+    - pattern: "ᆯᄏ"
+      result: "lk" # HANGUL JONGSEONG RIEUL + CHOSEONG KHIEUKH
+    - pattern: "ᆯᄐ"
+      result: "lt" # HANGUL JONGSEONG RIEUL + CHOSEONG THIEUTH
+    - pattern: "ᆯᄑ"
+      result: "lp" # HANGUL JONGSEONG RIEUL + CHOSEONG PHIEUPH
+    - pattern: "ᆯᄒ"
+      result: "rh" # HANGUL JONGSEONG RIEUL + CHOSEONG HIEUH
+    - pattern: "ᆯᄁ"
+      result: "lkk" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆯᄄ"
+      result: "ltt" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆯᄈ"
+      result: "lpp" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGPIEUP
+    - pattern: "ᆯᄊ"
+      result: "lss" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGSIOS
+    - pattern: "ᆯᄍ"
+      result: "ljj" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGCIEUC
+    - pattern: "ᆷᄀ"
+      result: "mg" # HANGUL JONGSEONG MIEUM + CHOSEONG KIYEOK
+    - pattern: "ᆷᄂ"
+      result: "mn" # HANGUL JONGSEONG MIEUM + CHOSEONG NIEUN
+    - pattern: "ᆷᄃ"
+      result: "md" # HANGUL JONGSEONG MIEUM + CHOSEONG TIKEUT
+    - pattern: "ᆷᄅ"
+      result: "mn" # HANGUL JONGSEONG MIEUM + CHOSEONG RIEUL
+    - pattern: "ᆷᄆ"
+      result: "mm" # HANGUL JONGSEONG MIEUM + CHOSEONG MIEUM
+    - pattern: "ᆷᄇ"
+      result: "mb" # HANGUL JONGSEONG MIEUM + CHOSEONG PIEUP
+    - pattern: "ᆷᄉ"
+      result: "ms" # HANGUL JONGSEONG MIEUM + CHOSEONG SIOS
+    - pattern: "ᆷᄋ"
+      result: "m" # HANGUL JONGSEONG MIEUM + CHOSEONG IEUNG
+    - pattern: "ᆷᄌ"
+      result: "mj" # HANGUL JONGSEONG MIEUM + CHOSEONG CIEUC
+    - pattern: "ᆷᄎ"
+      result: "mch" # HANGUL JONGSEONG MIEUM + CHOSEONG CHIEUCH
+    - pattern: "ᆷᄏ"
+      result: "mk" # HANGUL JONGSEONG MIEUM + CHOSEONG KHIEUKH
+    - pattern: "ᆷᄐ"
+      result: "mt" # HANGUL JONGSEONG MIEUM + CHOSEONG THIEUTH
+    - pattern: "ᆷᄑ"
+      result: "mp" # HANGUL JONGSEONG MIEUM + CHOSEONG PHIEUPH
+    - pattern: "ᆷᄒ"
+      result: "mh" # HANGUL JONGSEONG MIEUM + CHOSEONG HIEUH
+    - pattern: "ᆷᄁ"
+      result: "mkk" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆷᄄ"
+      result: "mtt" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆷᄈ"
+      result: "mpp" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGPIEUP
+    - pattern: "ᆷᄊ"
+      result: "mss" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGSIOS
+    - pattern: "ᆷᄍ"
+      result: "mjj" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGCIEUC
+    - pattern: "ᆸᄀ"
+      result: "pg" # HANGUL JONGSEONG PIEUP + CHOSEONG KIYEOK
+    - pattern: "ᆸᄂ"
+      result: "mn" # HANGUL JONGSEONG PIEUP + CHOSEONG NIEUN
+    - pattern: "ᆸᄃ"
+      result: "pd" # HANGUL JONGSEONG PIEUP + CHOSEONG TIKEUT
+    - pattern: "ᆸᄅ"
+      result: "mn" # HANGUL JONGSEONG PIEUP + CHOSEONG RIEUL
+    - pattern: "ᆸᄆ"
+      result: "mm" # HANGUL JONGSEONG PIEUP + CHOSEONG MIEUM
+    - pattern: "ᆸᄇ"
+      result: "pb" # HANGUL JONGSEONG PIEUP + CHOSEONG PIEUP
+    - pattern: "ᆸᄉ"
+      result: "ps" # HANGUL JONGSEONG PIEUP + CHOSEONG SIOS
+    - pattern: "ᆸᄋ"
+      result: "p" # HANGUL JONGSEONG PIEUP + CHOSEONG IEUNG
+    - pattern: "ᆸᄌ"
+      result: "pj" # HANGUL JONGSEONG PIEUP + CHOSEONG CIEUC
+    - pattern: "ᆸᄎ"
+      result: "pch" # HANGUL JONGSEONG PIEUP + CHOSEONG CHIEUCH
+    - pattern: "ᆸᄏ"
+      result: "pk" # HANGUL JONGSEONG PIEUP + CHOSEONG KHIEUKH
+    - pattern: "ᆸᄐ"
+      result: "pt" # HANGUL JONGSEONG PIEUP + CHOSEONG THIEUTH
+    - pattern: "ᆸᄑ"
+      result: "pp" # HANGUL JONGSEONG PIEUP + CHOSEONG PHIEUPH
+    - pattern: "ᆸᄒ"
+      result: "ph" # HANGUL JONGSEONG PIEUP + CHOSEONG HIEUH
+    - pattern: "ᆸᄁ"
+      result: "pkk" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆸᄄ"
+      result: "ptt" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆸᄈ"
+      result: "ppp" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGPIEUP
+    - pattern: "ᆸᄊ"
+      result: "pss" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGSIOS
+    - pattern: "ᆸᄍ"
+      result: "pjj" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGCIEUC
+    - pattern: "ᆺᄀ"
+      result: "tg" # HANGUL JONGSEONG SIOS + CHOSEONG KIYEOK
+    - pattern: "ᆺᄂ"
+      result: "nn" # HANGUL JONGSEONG SIOS + CHOSEONG NIEUN
+    - pattern: "ᆺᄃ"
+      result: "td" # HANGUL JONGSEONG SIOS + CHOSEONG TIKEUT
+    - pattern: "ᆺᄅ"
+      result: "nn" # HANGUL JONGSEONG SIOS + CHOSEONG RIEUL
+    - pattern: "ᆺᄆ"
+      result: "nm" # HANGUL JONGSEONG SIOS + CHOSEONG MIEUM
+    - pattern: "ᆺᄇ"
+      result: "tb" # HANGUL JONGSEONG SIOS + CHOSEONG PIEUP
+    - pattern: "ᆺᄉ"
+      result: "ts" # HANGUL JONGSEONG SIOS + CHOSEONG SIOS
+    - pattern: "ᆺᄋ"
+      result: "t" # HANGUL JONGSEONG SIOS + CHOSEONG IEUNG
+    - pattern: "ᆺᄌ"
+      result: "tj" # HANGUL JONGSEONG SIOS + CHOSEONG CIEUC
+    - pattern: "ᆺᄎ"
+      result: "tch" # HANGUL JONGSEONG SIOS + CHOSEONG CHIEUCH
+    - pattern: "ᆺᄏ"
+      result: "tk" # HANGUL JONGSEONG SIOS + CHOSEONG KHIEUKH
+    - pattern: "ᆺᄐ"
+      result: "tt" # HANGUL JONGSEONG SIOS + CHOSEONG THIEUTH
+    - pattern: "ᆺᄑ"
+      result: "tp’" # HANGUL JONGSEONG SIOS + CHOSEONG PHIEUPH
+    - pattern: "ᆺᄒ"
+      result: "th" # HANGUL JONGSEONG SIOS + CHOSEONG HIEUH
+    - pattern: "ᆺᄁ"
+      result: "tkk" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆺᄄ"
+      result: "ttt" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆺᄈ"
+      result: "tpp" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGPIEUP
+    - pattern: "ᆺᄊ"
+      result: "tss" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGSIOS
+    - pattern: "ᆺᄍ"
+      result: "tjj" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGCIEUC
+    - pattern: "ᆼᄀ"
+      result: "ngg" # HANGUL JONGSEONG IEUNG + CHOSEONG KIYEOK
+    - pattern: "ᆼᄂ"
+      result: "ngn" # HANGUL JONGSEONG IEUNG + CHOSEONG NIEUN
+    - pattern: "ᆼᄃ"
+      result: "ngd" # HANGUL JONGSEONG IEUNG + CHOSEONG TIKEUT
+    - pattern: "ᆼᄅ"
+      result: "ngn" # HANGUL JONGSEONG IEUNG + CHOSEONG RIEUL
+    - pattern: "ᆼᄆ"
+      result: "ngm" # HANGUL JONGSEONG IEUNG + CHOSEONG MIEUM
+    - pattern: "ᆼᄇ"
+      result: "ngb" # HANGUL JONGSEONG IEUNG + CHOSEONG PIEUP
+    - pattern: "ᆼᄉ"
+      result: "ngs" # HANGUL JONGSEONG IEUNG + CHOSEONG SIOS
+    - pattern: "ᆼᄋ"
+      result: "ng" # HANGUL JONGSEONG IEUNG + CHOSEONG IEUNG
+    - pattern: "ᆼᄌ"
+      result: "ngj" # HANGUL JONGSEONG IEUNG + CHOSEONG CIEUC
+    - pattern: "ᆼᄎ"
+      result: "ngch" # HANGUL JONGSEONG IEUNG + CHOSEONG CHIEUCH
+    - pattern: "ᆼᄏ"
+      result: "ngk" # HANGUL JONGSEONG IEUNG + CHOSEONG KHIEUKH
+    - pattern: "ᆼᄐ"
+      result: "ngt" # HANGUL JONGSEONG IEUNG + CHOSEONG THIEUTH
+    - pattern: "ᆼᄑ"
+      result: "ngp" # HANGUL JONGSEONG IEUNG + CHOSEONG PHIEUPH
+    - pattern: "ᆼᄒ"
+      result: "ngh" # HANGUL JONGSEONG IEUNG + CHOSEONG HIEUH
+    - pattern: "ᆼᄁ"
+      result: "ngkk" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆼᄄ"
+      result: "ngtt" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆼᄈ"
+      result: "ngpp" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGPIEUP
+    - pattern: "ᆼᄊ"
+      result: "ngss" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGSIOS
+    - pattern: "ᆼᄍ"
+      result: "ngjj" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGCIEUC
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄀ"
+      result: "\\1g" # HANGUL JONGSEONG KIYEOK + CHOSEONG KIYEOK
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄂ"
+      result: "\\1n" # HANGUL JONGSEONG KIYEOK + CHOSEONG NIEUN
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄃ"
+      result: "\\1d" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIKEUT
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄅ"
+      result: "\\1r" # HANGUL JONGSEONG KIYEOK + CHOSEONG RIEUL
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄆ"
+      result: "\\1m" # HANGUL JONGSEONG KIYEOK + CHOSEONG MIEUM
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄇ"
+      result: "\\1b" # HANGUL JONGSEONG KIYEOK + CHOSEONG PIEUP
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄉ"
+      result: "\\1s" # HANGUL JONGSEONG KIYEOK + CHOSEONG SIOS
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄋ"
+      result: "\\1" # HANGUL JONGSEONG KIYEOK + CHOSEONG IEUNG
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄌ"
+      result: "\\1j" # HANGUL JONGSEONG KIYEOK + CHOSEONG CIEUC
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄎ"
+      result: "\\1ch" # HANGUL JONGSEONG KIYEOK + CHOSEONG CHIEUCH
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄏ"
+      result: "\\1k" # HANGUL JONGSEONG KIYEOK + CHOSEONG KHIEUKH
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄐ"
+      result: "\\1t" # HANGUL JONGSEONG KIYEOK + CHOSEONG THIEUTH
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄑ"
+      result: "\\1p" # HANGUL JONGSEONG KIYEOK + CHOSEONG PHIEUPH
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄒ"
+      result: "h" # HANGUL JONGSEONG KIYEOK + CHOSEONG HIEUH
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄁ"
+      result: "kk" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGKIYEOK
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄄ"
+      result: "tt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIKEUT
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄈ"
+      result: "pp" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGPIEUP
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄊ"
+      result: "ss" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGSIOS
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄍ"
+      result: "jj" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGCIEUC
+    - pattern: "ᆰᄀ"
+      result: "lg" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG KIYEOK
+    - pattern: "ᆰᄂ"
+      result: "ngn" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG NIEUN
+    - pattern: "ᆰᄃ"
+      result: "kd" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG TIKEUT
+    - pattern: "ᆰᄅ"
+      result: "ngn" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG RIEUL
+    - pattern: "ᆰᄆ"
+      result: "ngm" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG MIEUM
+    - pattern: "ᆰᄇ"
+      result: "kb" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG PIEUP
+    - pattern: "ᆰᄉ"
+      result: "ks" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SIOS
+    - pattern: "ᆰᄋ"
+      result: "lg" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG IEUNG
+    - pattern: "ᆰᄌ"
+      result: "kj" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG CIEUC
+    - pattern: "ᆰᄎ"
+      result: "kch" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG CHIEUCH
+    - pattern: "ᆰᄏ"
+      result: "lk" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG KHIEUKH
+    - pattern: "ᆰᄐ"
+      result: "kt" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG THIEUTH
+    - pattern: "ᆰᄑ"
+      result: "kp" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG PHIEUPH
+    - pattern: "ᆰᄒ"
+      result: "lk" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG HIEUH
+    - pattern: "ᆰᄁ"
+      result: "lkk" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆰᄄ"
+      result: "ktt" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆰᄈ"
+      result: "kpp" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGPIEUP
+    - pattern: "ᆰᄊ"
+      result: "kss" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGSIOS
+    - pattern: "ᆰᄍ"
+      result: "kjj" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGCIEUC
+    - pattern: "ᆱᄀ"
+      result: "mg" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG KIYEOK
+    - pattern: "ᆱᄂ"
+      result: "mn" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG NIEUN
+    - pattern: "ᆱᄃ"
+      result: "md" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG TIKEUT
+    - pattern: "ᆱᄅ"
+      result: "ml" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG RIEUL
+    - pattern: "ᆱᄆ"
+      result: "lm" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG MIEUM
+    - pattern: "ᆱᄇ"
+      result: "mb" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG PIEUP
+    - pattern: "ᆱᄉ"
+      result: "ms" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SIOS
+    - pattern: "ᆱᄋ"
+      result: "lm" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG IEUNG
+    - pattern: "ᆱᄌ"
+      result: "mj" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG CIEUC
+    - pattern: "ᆱᄎ"
+      result: "mch" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG CHIEUCH
+    - pattern: "ᆱᄏ"
+      result: "mk" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG KHIEUKH
+    - pattern: "ᆱᄐ"
+      result: "mt" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG THIEUTH
+    - pattern: "ᆱᄑ"
+      result: "mp" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG PHIEUPH
+    - pattern: "ᆱᄒ"
+      result: "mh" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG HIEUH
+    - pattern: "ᆱᄁ"
+      result: "mkk" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆱᄄ"
+      result: "mtt" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆱᄈ"
+      result: "mpp" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGPIEUP
+    - pattern: "ᆱᄊ"
+      result: "mss" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGSIOS
+    - pattern: "ᆱᄍ"
+      result: "mjj" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGCIEUC
+    - pattern: "ᆲᄀ"
+      result: "pg" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG KIYEOK
+    - pattern: "ᆲᄂ"
+      result: "mn" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG NIEUN
+    - pattern: "ᆲᄃ"
+      result: "pd" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG TIKEUT
+    - pattern: "ᆲᄅ"
+      result: "mn" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG RIEUL
+    - pattern: "ᆲᄆ"
+      result: "mm" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG MIEUM
+    - pattern: "ᆲᄇ"
+      result: "lb" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG PIEUP
+    - pattern: "ᆲᄉ"
+      result: "ps" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SIOS
+    - pattern: "ᆲᄋ"
+      result: "lb" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG IEUNG
+    - pattern: "ᆲᄌ"
+      result: "pj" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG CIEUC
+    - pattern: "ᆲᄎ"
+      result: "pch" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG CHIEUCH
+    - pattern: "ᆲᄏ"
+      result: "pk" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG KHIEUKH
+    - pattern: "ᆲᄐ"
+      result: "pt" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG THIEUTH
+    - pattern: "ᆲᄑ"
+      result: "lp" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG PHIEUPH
+    - pattern: "ᆲᄒ"
+      result: "lp" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG HIEUH
+    - pattern: "ᆲᄁ"
+      result: "pkk" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆲᄄ"
+      result: "ptt" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGTIKEUT
+    - pattern: "ᆲᄈ"
+      result: "lpp" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGPIEUP
+    - pattern: "ᆲᄊ"
+      result: "pss" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGSIOS
+    - pattern: "ᆲᄍ"
+      result: "pjj" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGCIEUC
+    - pattern: "(?<= )ᄀ"
+      result: "g" # HANGUL CHOSEONG KIYEOK
+    - pattern: "(?<= )ᄂ"
+      result: "n" # HANGUL CHOSEONG NIEUN
+    - pattern: "(?<= )ᄃ"
+      result: "d" # HANGUL CHOSEONG TIKEUT
+    - pattern: "(?<= )ᄅ(?=[ᅣᅤᅧᅨᅭᅲ])"
+      result: "" # HANGUL CHOSEONG RIEUL # R-onset rule
+    - pattern: "(?<= )ᄅ"
+      result: "n" # HANGUL CHOSEONG RIEUL
+    - pattern: "(?<= )ᄆ"
+      result: "m" # HANGUL CHOSEONG MIEUM
+    - pattern: "(?<= )ᄇ"
+      result: "b" # HANGUL CHOSEONG PIEUP
+    - pattern: "(?<= )ᄉ"
+      result: "s" # HANGUL CHOSEONG SIOS
+    - pattern: "(?<= )ᄋ"
+      result: "" # HANGUL CHOSEONG IEUNG
+    - pattern: "(?<= )ᄌ"
+      result: "j" # HANGUL CHOSEONG CIEUC
+    - pattern: "(?<= )ᄎ"
+      result: "ch" # HANGUL CHOSEONG CHIEUCH
+    - pattern: "(?<= )ᄏ"
+      result: "k" # HANGUL CHOSEONG KHIEUKH
+    - pattern: "(?<= )ᄐ"
+      result: "t" # HANGUL CHOSEONG THIEUTH
+    - pattern: "(?<= )ᄑ"
+      result: "p" # HANGUL CHOSEONG PHIEUPH
+    - pattern: "(?<= )ᄒ"
+      result: "h" # HANGUL CHOSEONG HIEUH
+    - pattern: "(?<= )ᄁ"
+      result: "kk" # HANGUL CHOSEONG SSANGKIYEOK
+    - pattern: "(?<= )ᄭ"
+      result: "kk" # HANGUL CHOSEONG SIOS-KIYEOK
+    - pattern: "(?<= )ᄄ"
+      result: "tt" # HANGUL CHOSEONG SSANGTIKEUT
+    - pattern: "(?<= )ᄯ"
+      result: "tt" # HANGUL CHOSEONG SIOS-TIKEUT
+    - pattern: "(?<= )ᄈ"
+      result: "pp" # HANGUL CHOSEONG SSANGPIEUP
+    - pattern: "(?<= )ᄲ"
+      result: "pp" # HANGUL CHOSEONG SIOS-PIEUP
+    - pattern: "(?<= )ᄊ"
+      result: "ss" # HANGUL CHOSEONG SSANGSIOS
+    - pattern: "(?<= )ᄍ"
+      result: "jj" # HANGUL CHOSEONG SSANGCIEUC
+    - pattern: "(?<= )ᄶ"
+      result: "jj" # HANGUL CHOSEONG SIOS-CIEUC
+    - pattern: "ᅡ"
+      result: "a" # HANGUL JUNGSEONG A
+    - pattern: "ᅣ"
+      result: "ya" # HANGUL JUNGSEONG YA
+    - pattern: "ᅥ"
+      result: "eo" # HANGUL JUNGSEONG EO
+    - pattern: "ᅧ"
+      result: "yeo" # HANGUL JUNGSEONG YEO
+    - pattern: "ᅩ"
+      result: "o" # HANGUL JUNGSEONG O
+    - pattern: "ᅭ"
+      result: "yo" # HANGUL JUNGSEONG YO
+    - pattern: "ᅮ"
+      result: "u" # HANGUL JUNGSEONG U
+    - pattern: "ᅲ"
+      result: "yu" # HANGUL JUNGSEONG YU
+    - pattern: "ᅳ"
+      result: "eu" # HANGUL JUNGSEONG EU
+    - pattern: "ᅵ"
+      result: "i" # HANGUL JUNGSEONG I
+    - pattern: "ᅢ"
+      result: "ae" # HANGUL JUNGSEONG AE
+    - pattern: "ᅤ"
+      result: "yae" # HANGUL JUNGSEONG YAE
+    - pattern: "ᅦ"
+      result: "e" # HANGUL JUNGSEONG E
+    - pattern: "ᅨ"
+      result: "ye" # HANGUL JUNGSEONG YE
+    - pattern: "ᅬ"
+      result: "oe" # HANGUL JUNGSEONG OE
+    - pattern: "ᅱ"
+      result: "wi" # HANGUL JUNGSEONG WI
+    - pattern: "ᅴ"
+      result: "ui" # HANGUL JUNGSEONG YI
+    - pattern: "ᅪ"
+      result: "wa" # HANGUL JUNGSEONG WA
+    - pattern: "ᅯ"
+      result: "wo" # HANGUL JUNGSEONG WEO
+    - pattern: "ᅫ"
+      result: "wae" # HANGUL JUNGSEONG WAE
+    - pattern: "ᅰ"
+      result: "we" # HANGUL JUNGSEONG WE
+    - pattern: "ᆨ(?=[ -])"
+      result: "k" # HANGUL JONGSEONG KIYEOK
+    - pattern: "ᆫ(?=[ -])"
+      result: "n" # HANGUL JONGSEONG NIEUN
+    - pattern: "ᆮ(?=[ -])"
+      result: "t" # HANGUL JONGSEONG TIKEUT
+    - pattern: "ᆯ(?=[ -])"
+      result: "l" # HANGUL JONGSEONG RIEUL
+    - pattern: "ᆷ(?=[ -])"
+      result: "m" # HANGUL JONGSEONG MIEUM
+    - pattern: "ᆸ(?=[ -])"
+      result: "p" # HANGUL JONGSEONG PIEUP
+    - pattern: "ᆺ(?=[ -])"
+      result: "t" # HANGUL JONGSEONG SIOS
+    - pattern: "ᆼ(?=[ -])"
+      result: "ng" # HANGUL JONGSEONG IEUNG
+    - pattern: "ᆽ(?=[ -])"
+      result: "t" # HANGUL JONGSEONG CIEUC
+    - pattern: "ᆾ(?=[ -])"
+      result: "t" # HANGUL JONGSEONG CHIEUCH
+    - pattern: "ᆿ(?=[ -])"
+      result: "k" # HANGUL JONGSEONG KHIEUKH
+    - pattern: "ᇀ(?=[ -])"
+      result: "t" # HANGUL JONGSEONG THIEUTH
+    - pattern: "ᇁ(?=[ -])"
+      result: "p" # HANGUL JONGSEONG PHIEUPH
+    - pattern: "ᆰ(?=[ -])"
+      result: "k" # HANGUL JONGSEONG RIEUL-KIYEOK
+    - pattern: "ᆲ(?=[ -])"
+      result: "p" # HANGUL JONGSEONG RIEUL-PIEUP
+
+    # Remove space added
+    - pattern: "^ "
+      result: ""
+    - pattern: " $"
+      result: ""
+
+  characters:
+  # This is based on Jamo

--- a/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
+++ b/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
@@ -1,18 +1,17 @@
 ---
-authority_id: bgn
-id: 1939
+authority_id: moct
+id: 2000
 language: kor
 source_script: Hang
 destination_script: Latn
-name: BGN Agreement -- Korean McCune-Reischauer System (1943)
-url: http://geonames.nga.mil/gns/html/Romanization/ROMANIZATION%20OF%20KOREAN-%20MR%20for%20DPRK.pdf
-creation_date: 1939
-adoption_date: 
+name: Korean Ministry of Culture and Tourism 2000 System
+url: https://www.korean.go.kr/front_eng/roman/roman_01.do
+creation_date: 2000
+adoption_date: 2002
 description:
 
 notes:
-  BGN/PCGN 1945 Agreement
-
+  
 tests:
   - source: 불국사
     expected: "Bulguksa"

--- a/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
+++ b/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
@@ -1,6 +1,6 @@
 ---
 authority_id: moct
-id: 2000
+id: 2000-viajamo
 language: kor
 source_script: Hang
 destination_script: Latn
@@ -8,10 +8,57 @@ name: Korean Ministry of Culture and Tourism 2000 System
 url: https://www.korean.go.kr/front_eng/roman/roman_01.do
 creation_date: 2000
 adoption_date: 2002
-description:
+description: |
+  Generation of Jamo from Hangul
+
+  This is how the Hangul-to-Jamo maps are generated. Please refer to this page
+  for details about Korean text handling in Unicode.
+  http://gernot-katzers-spice-pages.com/var/korean_hangul_unicode.html
+
+  This formula copied from the page above is used:
+  [stem]
+  ====
+  tail = mod (Hangul codepoint − 44032, 28)
+  vowel = 1 + mod (Hangul codepoint − 44032 − tail, 588) / 28
+  lead = 1 + int [ (Hangul codepoint − 44032)/588 ]
+  ====
+
+  [source,python]
+  ----
+  import pandas as pd
+  import re
+  import math
+
+  leadjamo = [chr(0x1100+i) for i in range(0,19)]
+  # ᄀᄁᄂᄃᄄᄅᄆᄇᄈᄉᄊᄋᄌᄍᄎᄏᄐᄑᄒ
+  voweljamo = [chr(0x1161+i) for i in range(0,21)]
+  # ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ
+  tailjamo = ['']+[chr(0x11A8+i) for i in range(0,27)]
+  # ᆨᆩᆪᆫᆬᆭᆮᆯᆰᆱᆲᆳᆴᆵᆶᆷᆸᆹᆺᆻᆼᆽᆾᆿᇀᇁᇂ
+
+  hanguls = [chr(i) for i in range(44032,55172)]
+  tails = [tailjamo[(i-44032) % 28] for i in range(44032,55172)]
+  vowels = [voweljamo[((i-44032-((i-44032) % 28)) % 588) // 28] for i in range(44032,55172)]
+  leads = [leadjamo[math.floor((i-44032)// 588)] for i in range(44032,55172)]
+
+  kr_df = pd.DataFrame({'Hangul':hanguls, 'Lead':leads,'Vowel':vowels, 'Tail':tails})
+  ----
+
+  Hangul	Lead	Vowel	Tail
+  0	가	ᄀ	ᅡ
+  1	각	ᄀ	ᅡ	ᆨ
+  2	갂	ᄀ	ᅡ	ᆩ
+  3	갃	ᄀ	ᅡ	ᆪ
+  4	간	ᄀ	ᅡ	ᆫ
+  5	갅	ᄀ	ᅡ	ᆬ
+  6	갆	ᄀ	ᅡ	ᆭ
+  7	갇	ᄀ	ᅡ	ᆮ
+  8	갈	ᄀ	ᅡ	ᆯ
+  9	갉	ᄀ	ᅡ	ᆰ
+
 
 notes:
-  
+
 tests:
   - source: 불국사
     expected: "Bulguksa"
@@ -47,7 +94,7 @@ map:
   rules:
     # convert numbers to space + Hangul
     - pattern: "([^0-9 ])(?=[0-9])"
-      result: "\\1 "      
+      result: "\\1 "
     - pattern: "1"
       result: "일"
     - pattern: "2"
@@ -68,7 +115,7 @@ map:
       result: "구"
 
     # add hyphen in front of generics
-    - pattern: "(?<=.)(도|시|군|구|읍|면|리|동|가)$" 
+    - pattern: "(?<=.)(도|시|군|구|읍|면|리|동|가)$"
       result: "-\\1"
 
   postrules:


### PR DESCRIPTION
This is a follow-up of #206 .

Here are the maps for `bgn-kor-Hang-Latn-1939` and `moct-kor-Hang-Latn-2000` implemented using Jamo as an intermediate conversion. 

*Pros:*
- The same Hangul to decomposed Jamo map can be used by multiple transliteration maps
- Shorter files for each transliteration map
- Will not break other English words in Korean text

*Cons:*
- These maps are less transparent
(e.g. the coda nasalisation rules are scattered across multiple lines)
- Decomposed Jamos are not easy to manage manually (e.g. some text editors don't display them correctly, the same Jamo at different positions look exactly the same but have different Unicode codepoints)
<img src="https://user-images.githubusercontent.com/5143421/72658041-81bb0480-39e6-11ea-905a-500a6a2200a8.png" height="200" style="margin:100px">

I think the Jamo implementation is better, since there will be foreign words / alphanumeric characters in Korean text.