### PR TITLE
Korean maps

### DIFF
--- a/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
+++ b/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
@@ -7,7 +7,7 @@ destination_script: Latn
 name: BGN Agreement -- Korean McCune-Reischauer System (1943)
 url: http://geonames.nga.mil/gns/html/Romanization/ROMANIZATION%20OF%20KOREAN-%20MR%20for%20DPRK.pdf
 creation_date: 1939
-adoption_date: 
+adoption_date:
 description:
 
 notes:
@@ -16,7 +16,7 @@ notes:
 tests:
   - source: 은하리
     expected: "Ŭnha-ri"
-  - source: 은중리   
+  - source: 은중리
     expected: "Ŭnjung-ni"
   - source: 은장령
     expected: "Ŭnjang-nyŏng"
@@ -88,7 +88,7 @@ map:
   rules:
     # convert numbers to space + Hangul
     - pattern: "([^0-9 ])(?=[0-9])"
-      result: "\\1 "      
+      result: "\\1 "
     - pattern: "1"
       result: "일"
     - pattern: "2"
@@ -185,7 +185,7 @@ map:
       result: "ᆯ\\1ᄎ"
     - pattern: "ᆶ(-?)"
       result: "ᆯ\\1"
-    
+
     # HANGUL JONGSEONG PIEUP-SIOS
     - pattern: "ᆹ(-?)ᄋ"
       result: "ᄇ\\1ᄉ"
@@ -197,7 +197,7 @@ map:
       result: "ᆺ\\1ᄊ"
     - pattern: "ᆻ(-?)"
       result: "ᆺ\\1"
-    
+
     # HANGUL JONGSEONG CIEUC
     - pattern: "ᆽ(-?)ᄋ"
       result: "ᆺ\\1ᄌ"

--- a/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
+++ b/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
@@ -120,14 +120,138 @@ map:
     - pattern: "$"
       result: " "
 
+    # HANGUL JONGSEONG SSANGKIYEOK
+    - pattern: "ᆩ(-?)ᄋ"
+      result: "ᆨ\\1ᄁ"
+    - pattern: "ᆩ(-?)"
+      result: "ᆨ\\1"
+
+    # HANGUL JONGSEONG SSANGKIYEOK
+    - pattern: "ᆪ(-?)ᄋ"
+      result: "ᆨ\\1ᄉ"
+    - pattern: "ᆪ(-?)"
+      result: "ᆨ\\1"
+
+    # HANGUL JONGSEONG NIEUN-CIEUC
+    - pattern: "ᆬ(-?)ᄋ"
+      result: "ᆫ\\1ᄌ"
+    - pattern: "ᆬ(-?)"
+      result: "ᆫ\\1"
+
+    # HANGUL JONGSEONG NIEUN-CIEUC
+    - pattern: "ᆭ(-?)ᄀ"
+      result: "ᆫ\\1ᄏ"
+    - pattern: "ᆭ(-?)ᄃ"
+      result: "ᆫ\\1ᄐ"
+    - pattern: "ᆭ(-?)ᄇ"
+      result: "ᆫ\\1ᄑ"
+    - pattern: "ᆭ(-?)ᄌ"
+      result: "ᆫ\\1ᄎ"
+    - pattern: "ᆭ(-?)"
+      result: "ᆫ\\1"
+
+    # HANGUL JONGSEONG TIEUT
+    - pattern: "ᆮ(-?)(?=[ᄀᄁᄂᄃᄄᄅᄆᄇᄈᄉᄊᄌᄍᄎᄏᄐᄑᄒ])"
+      result: "ᆺ\\1"
+
+    # HANGUL JONGSEONG RIEUL-SIOS
+    - pattern: "ᆳ(-?)ᄋ"
+      result: "ᆯ\\1ᄉ"
+    - pattern: "ᆳ(-?)"
+      result: "ᆯ\\1"
+
+    # HANGUL JONGSEONG RIEUL-THIEUTH
+    - pattern: "ᆴ(-?)ᄋ"
+      result: "ᆯ\\1ᄐ"
+    - pattern: "ᆴ(-?)"
+      result: "ᆯ\\1"
+
+    # HANGUL JONGSEONG RIEUL-PHIEUPH
+    - pattern: "ᆵ(-?)ᄋ"
+      result: "ᆯ\\1ᄑ"
+    - pattern: "ᆵ(-?)(?=[ᄃᄄᄐ])"
+      result: "ᆯ\\1"
+    - pattern: "ᆵ(-?)"
+      result: "ᄇ\\1"
+
+    # HANGUL JONGSEONG RIEUL-HIEUH
+    - pattern: "ᆶ(-?)ᄀ"
+      result: "ᆯ\\1ᄏ"
+    - pattern: "ᆶ(-?)ᄃ"
+      result: "ᆯ\\1ᄐ"
+    - pattern: "ᆶ(-?)ᄇ"
+      result: "ᆯ\\1ᄑ"
+    - pattern: "ᆶ(-?)ᄌ"
+      result: "ᆯ\\1ᄎ"
+    - pattern: "ᆶ(-?)"
+      result: "ᆯ\\1"
+    
+    # HANGUL JONGSEONG PIEUP-SIOS
+    - pattern: "ᆹ(-?)ᄋ"
+      result: "ᄇ\\1ᄉ"
+    - pattern: "ᆹ(-?)"
+      result: "ᄇ\\1"
+
+    # HANGUL JONGSEONG SSANG-SIOS
+    - pattern: "ᆻ(-?)ᄋ"
+      result: "ᆺ\\1ᄊ"
+    - pattern: "ᆻ(-?)"
+      result: "ᆺ\\1"
+    
+    # HANGUL JONGSEONG CIEUC
+    - pattern: "ᆽ(-?)ᄋ"
+      result: "ᆺ\\1ᄌ"
+    - pattern: "ᆽ(-?)"
+      result: "ᆺ\\1"
+
+    # HANGUL JONGSEONG CHIEUCH
+    - pattern: "ᆾ(-?)ᄋ"
+      result: "ᆺ\\1ᄎ"
+    - pattern: "ᆾ(-?)"
+      result: "ᆺ\\1"
+
+    # HANGUL JONGSEONG KHIEUKH
+    - pattern: "ᆿ(-?)ᄋ"
+      result: "ᆨ\\1ᄏ"
+    - pattern: "ᆿ(-?)"
+      result: "ᆨ\\1"
+
+    # HANGUL JONGSEONG THIEUTH
+    - pattern: "ᇀ(-?)ᄋ"
+      result: "ᆺ\\1ᄐ"
+    - pattern: "ᇀ(-?)"
+      result: "ᆺ\\1"
+
+    # HANGUL JONGSEONG PHIEUPH
+    - pattern: "ᇁ(-?)ᄋ"
+      result: "ᆸ\\1ᄑ"
+    - pattern: "ᇁ(-?)"
+      result: "ᆸ\\1"
+
+    # HANGUL JONGSEONG HIEUH
+    - pattern: "ᇂ(-?)ᄀ"
+      result: "\\1ᄏ"
+    - pattern: "ᇂ(-?)ᄃ"
+      result: "\\1ᄐ"
+    - pattern: "ᇂ(-?)ᄇ"
+      result: "\\1ᄑ"
+    - pattern: "ᇂ(-?)ᄌ"
+      result: "\\1ᄎ"
+    - pattern: "ᇂ(-?)"
+      result: "\\1"
+
     # From Unicode Chart
     # https://github.com/unicode-org/cldr/blob/master/common/transforms/Korean-Latin-BGN.xml
+
+    - pattern: "ᆮ(-?)ᄋ" # HANGUL JONGSEONG TIEUT + CHOSEONG IEUNG
+      result: "\\1d"
+
     - pattern: "ᆨ(-?)ᄀ"
       result: "k\\1k" # HANGUL JONGSEONG KIYEOK + CHOSEONG KIYEOK
     - pattern: "ᆨ(-?)ᄂ"
       result: "ng\\1n" # HANGUL JONGSEONG KIYEOK + CHOSEONG NIEUN
     - pattern: "ᆨ(-?)ᄃ"
-      result: "k\\1t" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIKEUT
+      result: "k\\1t" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIEUT
     - pattern: "ᆨ(-?)ᄅ"
       result: "ng\\1n" # HANGUL JONGSEONG KIYEOK + CHOSEONG RIEUL
     - pattern: "ᆨ(-?)ᄆ"
@@ -137,7 +261,7 @@ map:
     - pattern: "ᆨ(-?)ᄉ"
       result: "k\\1s" # HANGUL JONGSEONG KIYEOK + CHOSEONG SIOS
     - pattern: "ᆨ(-?)ᄋ"
-      result: "g\\1" # HANGUL JONGSEONG KIYEOK + CHOSEONG IEUNG
+      result: "\\1g" # HANGUL JONGSEONG KIYEOK + CHOSEONG IEUNG
     - pattern: "ᆨ(-?)ᄌ"
       result: "k\\1ch" # HANGUL JONGSEONG KIYEOK + CHOSEONG CIEUC
     - pattern: "ᆨ(-?)ᄎ"
@@ -153,7 +277,7 @@ map:
     - pattern: "ᆨ(-?)ᄁ"
       result: "k\\1k" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGKIYEOK
     - pattern: "ᆨ(-?)ᄄ"
-      result: "k\\1tt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIKEUT
+      result: "k\\1tt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIEUT
     - pattern: "ᆨ(-?)ᄈ"
       result: "k\\1pp" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGPIEUP
     - pattern: "ᆨ(-?)ᄊ"
@@ -167,7 +291,7 @@ map:
     - pattern: "ᆫ(-?)ᄂ"
       result: "n\\1n" # HANGUL JONGSEONG NIEUN + CHOSEONG NIEUN
     - pattern: "ᆫ(-?)ᄃ"
-      result: "n\\1d" # HANGUL JONGSEONG NIEUN + CHOSEONG TIKEUT
+      result: "n\\1d" # HANGUL JONGSEONG NIEUN + CHOSEONG TIEUT
     - pattern: "ᆫ(-?)ᄅ"
       result: "l\\1l" # HANGUL JONGSEONG NIEUN + CHOSEONG RIEUL
     - pattern: "ᆫ(-?)ᄆ"
@@ -193,7 +317,7 @@ map:
     - pattern: "ᆫ(-?)ᄁ"
       result: "n\\1kk" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGKIYEOK
     - pattern: "ᆫ(-?)ᄄ"
-      result: "n\\1tt" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGTIKEUT
+      result: "n\\1tt" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGTIEUT
     - pattern: "ᆫ(-?)ᄈ"
       result: "n\\1pp" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGPIEUP
     - pattern: "ᆫ(-?)ᄊ"
@@ -205,7 +329,7 @@ map:
     - pattern: "ᆯ(-?)ᄂ"
       result: "l\\1l" # HANGUL JONGSEONG RIEUL + CHOSEONG NIEUN
     - pattern: "ᆯ(-?)ᄃ"
-      result: "l\\1t" # HANGUL JONGSEONG RIEUL + CHOSEONG TIKEUT
+      result: "l\\1t" # HANGUL JONGSEONG RIEUL + CHOSEONG TIEUT
     - pattern: "ᆯ(-?)ᄅ"
       result: "l\\1l" # HANGUL JONGSEONG RIEUL + CHOSEONG RIEUL
     - pattern: "ᆯ(-?)ᄆ"
@@ -215,7 +339,7 @@ map:
     - pattern: "ᆯ(-?)ᄉ"
       result: "l\\1s" # HANGUL JONGSEONG RIEUL + CHOSEONG SIOS
     - pattern: "ᆯ(-?)ᄋ"
-      result: "r\\1" # HANGUL JONGSEONG RIEUL + CHOSEONG IEUNG
+      result: "\\1r" # HANGUL JONGSEONG RIEUL + CHOSEONG IEUNG
     - pattern: "ᆯ(-?)ᄌ"
       result: "l\\1ch" # HANGUL JONGSEONG RIEUL + CHOSEONG CIEUC
     - pattern: "ᆯ(-?)ᄎ"
@@ -231,7 +355,7 @@ map:
     - pattern: "ᆯ(-?)ᄁ"
       result: "l\\1kk" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGKIYEOK
     - pattern: "ᆯ(-?)ᄄ"
-      result: "l\\1tt" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGTIKEUT
+      result: "l\\1tt" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGTIEUT
     - pattern: "ᆯ(-?)ᄈ"
       result: "l\\1pp" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGPIEUP
     - pattern: "ᆯ(-?)ᄊ"
@@ -243,7 +367,7 @@ map:
     - pattern: "ᆷ(-?)ᄂ"
       result: "m\\1n" # HANGUL JONGSEONG MIEUM + CHOSEONG NIEUN
     - pattern: "ᆷ(-?)ᄃ"
-      result: "m\\1d" # HANGUL JONGSEONG MIEUM + CHOSEONG TIKEUT
+      result: "m\\1d" # HANGUL JONGSEONG MIEUM + CHOSEONG TIEUT
     - pattern: "ᆷ(-?)ᄅ"
       result: "m\\1n" # HANGUL JONGSEONG MIEUM + CHOSEONG RIEUL
     - pattern: "ᆷ(-?)ᄆ"
@@ -269,7 +393,7 @@ map:
     - pattern: "ᆷ(-?)ᄁ"
       result: "m\\1kk" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGKIYEOK
     - pattern: "ᆷ(-?)ᄄ"
-      result: "m\\1tt" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGTIKEUT
+      result: "m\\1tt" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGTIEUT
     - pattern: "ᆷ(-?)ᄈ"
       result: "m\\1pp" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGPIEUP
     - pattern: "ᆷ(-?)ᄊ"
@@ -281,7 +405,7 @@ map:
     - pattern: "ᆸ(-?)ᄂ"
       result: "m\\1n" # HANGUL JONGSEONG PIEUP + CHOSEONG NIEUN
     - pattern: "ᆸ(-?)ᄃ"
-      result: "p\\1t" # HANGUL JONGSEONG PIEUP + CHOSEONG TIKEUT
+      result: "p\\1t" # HANGUL JONGSEONG PIEUP + CHOSEONG TIEUT
     - pattern: "ᆸ(-?)ᄅ"
       result: "m\\1n" # HANGUL JONGSEONG PIEUP + CHOSEONG RIEUL
     - pattern: "ᆸ(-?)ᄆ"
@@ -307,7 +431,7 @@ map:
     - pattern: "ᆸ(-?)ᄁ"
       result: "p\\1kk" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGKIYEOK
     - pattern: "ᆸ(-?)ᄄ"
-      result: "p\\1tt" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGTIKEUT
+      result: "p\\1tt" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGTIEUT
     - pattern: "ᆸ(-?)ᄈ"
       result: "p\\1p" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGPIEUP
     - pattern: "ᆸ(-?)ᄊ"
@@ -319,7 +443,7 @@ map:
     - pattern: "ᆺ(-?)ᄂ"
       result: "n\\1n" # HANGUL JONGSEONG SIOS + CHOSEONG NIEUN
     - pattern: "ᆺ(-?)ᄃ"
-      result: "t\\1t" # HANGUL JONGSEONG SIOS + CHOSEONG TIKEUT
+      result: "t\\1t" # HANGUL JONGSEONG SIOS + CHOSEONG TIEUT
     - pattern: "ᆺ(-?)ᄅ"
       result: "n\\1n" # HANGUL JONGSEONG SIOS + CHOSEONG RIEUL
     - pattern: "ᆺ(-?)ᄆ"
@@ -329,7 +453,7 @@ map:
     - pattern: "ᆺ(-?)ᄉ"
       result: "s\\1s" # HANGUL JONGSEONG SIOS + CHOSEONG SIOS
     - pattern: "ᆺ(-?)ᄋ"
-      result: "d\\1" # HANGUL JONGSEONG SIOS + CHOSEONG IEUNG
+      result: "s\\1" # HANGUL JONGSEONG SIOS + CHOSEONG IEUNG
     - pattern: "ᆺ(-?)ᄌ"
       result: "t\\1ch" # HANGUL JONGSEONG SIOS + CHOSEONG CIEUC
     - pattern: "ᆺ(-?)ᄎ"
@@ -345,7 +469,7 @@ map:
     - pattern: "ᆺ(-?)ᄁ"
       result: "t\\1kk" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGKIYEOK
     - pattern: "ᆺ(-?)ᄄ"
-      result: "t\\1t" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGTIKEUT
+      result: "t\\1t" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGTIEUT
     - pattern: "ᆺ(-?)ᄈ"
       result: "t\\1pp" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGPIEUP
     - pattern: "ᆺ(-?)ᄊ"
@@ -357,7 +481,7 @@ map:
     - pattern: "ᆼ(-?)ᄂ"
       result: "ng\\1n" # HANGUL JONGSEONG IEUNG + CHOSEONG NIEUN
     - pattern: "ᆼ(-?)ᄃ"
-      result: "ng\\1d" # HANGUL JONGSEONG IEUNG + CHOSEONG TIKEUT
+      result: "ng\\1d" # HANGUL JONGSEONG IEUNG + CHOSEONG TIEUT
     - pattern: "ᆼ(-?)ᄅ"
       result: "ng\\1n" # HANGUL JONGSEONG IEUNG + CHOSEONG RIEUL
     - pattern: "ᆼ(-?)ᄆ"
@@ -383,7 +507,7 @@ map:
     - pattern: "ᆼ(-?)ᄁ"
       result: "ng\\1kk" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGKIYEOK
     - pattern: "ᆼ(-?)ᄄ"
-      result: "ng\\1tt" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGTIKEUT
+      result: "ng\\1tt" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGTIEUT
     - pattern: "ᆼ(-?)ᄈ"
       result: "ng\\1pp" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGPIEUP
     - pattern: "ᆼ(-?)ᄊ"
@@ -395,7 +519,7 @@ map:
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄂ"
       result: "\\1n" # HANGUL JONGSEONG KIYEOK + CHOSEONG NIEUN
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄃ"
-      result: "\\1d" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIKEUT
+      result: "\\1d" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIEUT
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄅ"
       result: "\\1r" # HANGUL JONGSEONG KIYEOK + CHOSEONG RIEUL
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄆ"
@@ -421,7 +545,7 @@ map:
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄁ"
       result: "\\1kk" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGKIYEOK
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄄ"
-      result: "\\1tt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIKEUT
+      result: "\\1tt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIEUT
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄈ"
       result: "\\1pp" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGPIEUP
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄊ"
@@ -433,7 +557,7 @@ map:
     - pattern: "ᆰ(-?)ᄂ"
       result: "ng\\1n" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG NIEUN
     - pattern: "ᆰ(-?)ᄃ"
-      result: "k\\1t" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG TIKEUT
+      result: "k\\1t" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG TIEUT
     - pattern: "ᆰ(-?)ᄅ"
       result: "ng\\1n" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG RIEUL
     - pattern: "ᆰ(-?)ᄆ"
@@ -459,7 +583,7 @@ map:
     - pattern: "ᆰ(-?)ᄁ"
       result: "l\\1kk" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGKIYEOK
     - pattern: "ᆰ(-?)ᄄ"
-      result: "k\\1tt" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGTIKEUT
+      result: "k\\1tt" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGTIEUT
     - pattern: "ᆰ(-?)ᄈ"
       result: "k\\1pp" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGPIEUP
     - pattern: "ᆰ(-?)ᄊ"
@@ -471,7 +595,7 @@ map:
     - pattern: "ᆱ(-?)ᄂ"
       result: "m\\1n" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG NIEUN
     - pattern: "ᆱ(-?)ᄃ"
-      result: "m\\1d" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG TIKEUT
+      result: "m\\1d" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG TIEUT
     - pattern: "ᆱ(-?)ᄅ"
       result: "m\\1n" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG RIEUL
     - pattern: "ᆱ(-?)ᄆ"
@@ -481,7 +605,7 @@ map:
     - pattern: "ᆱ(-?)ᄉ"
       result: "m\\1s" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SIOS
     - pattern: "ᆱ(-?)ᄋ"
-      result: "lm\\1" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG IEUNG
+      result: "l\\1m" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG IEUNG
     - pattern: "ᆱ(-?)ᄌ"
       result: "m\\1j" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG CIEUC
     - pattern: "ᆱ(-?)ᄎ"
@@ -497,7 +621,7 @@ map:
     - pattern: "ᆱ(-?)ᄁ"
       result: "m\\1kk" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGKIYEOK
     - pattern: "ᆱ(-?)ᄄ"
-      result: "m\\1tt" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGTIKEUT
+      result: "m\\1tt" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGTIEUT
     - pattern: "ᆱ(-?)ᄈ"
       result: "m\\1pp" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGPIEUP
     - pattern: "ᆱ(-?)ᄊ"
@@ -509,7 +633,7 @@ map:
     - pattern: "ᆲ(-?)ᄂ"
       result: "mn" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG NIEUN
     - pattern: "ᆲ(-?)ᄃ"
-      result: "p\\1t" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG TIKEUT
+      result: "p\\1t" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG TIEUT
     - pattern: "ᆲ(-?)ᄅ"
       result: "m\\1n" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG RIEUL
     - pattern: "ᆲ(-?)ᄆ"
@@ -519,7 +643,7 @@ map:
     - pattern: "ᆲ(-?)ᄉ"
       result: "p\\1s" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SIOS
     - pattern: "ᆲ(-?)ᄋ"
-      result: "lb\\1" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG IEUNG
+      result: "l\\1b" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG IEUNG
     - pattern: "ᆲ(-?)ᄌ"
       result: "p\\1ch" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG CIEUC
     - pattern: "ᆲ(-?)ᄎ"
@@ -535,7 +659,7 @@ map:
     - pattern: "ᆲ(-?)ᄁ"
       result: "p\\1kk" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGKIYEOK
     - pattern: "ᆲ(-?)ᄄ"
-      result: "p\\1tt" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGTIKEUT
+      result: "p\\1tt" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGTIEUT
     - pattern: "ᆲ(-?)ᄈ"
       result: "l\\1pp" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGPIEUP
     - pattern: "ᆲ(-?)ᄊ"
@@ -547,7 +671,7 @@ map:
     - pattern: "(?<= )ᄂ"
       result: "n" # HANGUL CHOSEONG NIEUN
     - pattern: "(?<= )ᄃ"
-      result: "t" # HANGUL CHOSEONG TIKEUT
+      result: "t" # HANGUL CHOSEONG TIEUT
     - pattern: "(?<= )ᄅ(?=[ᅣᅤᅧᅨᅭᅲ])"
       result: "" # HANGUL CHOSEONG RIEUL # R-onset rule
     - pattern: "(?<= )ᄅ"
@@ -577,9 +701,9 @@ map:
     - pattern: "(?<= )ᄭ"
       result: "kk" # HANGUL CHOSEONG SIOS-KIYEOK
     - pattern: "(?<= )ᄄ"
-      result: "tt" # HANGUL CHOSEONG SSANGTIKEUT
+      result: "tt" # HANGUL CHOSEONG SSANGTIEUT
     - pattern: "(?<= )ᄯ"
-      result: "tt" # HANGUL CHOSEONG SIOS-TIKEUT
+      result: "tt" # HANGUL CHOSEONG SIOS-TIEUT
     - pattern: "(?<= )ᄈ"
       result: "pp" # HANGUL CHOSEONG SSANGPIEUP
     - pattern: "(?<= )ᄲ"
@@ -637,7 +761,7 @@ map:
     - pattern: "ᆫ(?=[ -])"
       result: "n" # HANGUL JONGSEONG NIEUN
     - pattern: "ᆮ(?=[ -])"
-      result: "t" # HANGUL JONGSEONG TIKEUT
+      result: "t" # HANGUL JONGSEONG TIEUT
     - pattern: "ᆯ(?=[ -])"
       result: "l" # HANGUL JONGSEONG RIEUL
     - pattern: "ᆷ(?=[ -])"

--- a/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
+++ b/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
@@ -515,43 +515,43 @@ map:
     - pattern: "ᆼ(-?)ᄍ"
       result: "ng\\1tch" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGCIEUC
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄀ"
-      result: "\\1g" # HANGUL JONGSEONG KIYEOK + CHOSEONG KIYEOK
+      result: "\\1g" # VOWEL + CHOSEONG KIYEOK
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄂ"
-      result: "\\1n" # HANGUL JONGSEONG KIYEOK + CHOSEONG NIEUN
+      result: "\\1n" # VOWEL + CHOSEONG NIEUN
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄃ"
-      result: "\\1d" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIEUT
+      result: "\\1d" # VOWEL + CHOSEONG TIEUT
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄅ"
-      result: "\\1r" # HANGUL JONGSEONG KIYEOK + CHOSEONG RIEUL
+      result: "\\1r" # VOWEL + CHOSEONG RIEUL
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄆ"
-      result: "\\1m" # HANGUL JONGSEONG KIYEOK + CHOSEONG MIEUM
+      result: "\\1m" # VOWEL + CHOSEONG MIEUM
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄇ"
-      result: "\\1b" # HANGUL JONGSEONG KIYEOK + CHOSEONG PIEUP
+      result: "\\1b" # VOWEL + CHOSEONG PIEUP
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄉ"
-      result: "\\1s" # HANGUL JONGSEONG KIYEOK + CHOSEONG SIOS
+      result: "\\1s" # VOWEL + CHOSEONG SIOS
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄋ"
-      result: "\\1" # HANGUL JONGSEONG KIYEOK + CHOSEONG IEUNG
+      result: "\\1" # VOWEL + CHOSEONG IEUNG
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄌ"
-      result: "\\1j" # HANGUL JONGSEONG KIYEOK + CHOSEONG CIEUC
+      result: "\\1j" # VOWEL + CHOSEONG CIEUC
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄎ"
-      result: "\\1ch’" # HANGUL JONGSEONG KIYEOK + CHOSEONG CHIEUCH
+      result: "\\1ch’" # VOWEL + CHOSEONG CHIEUCH
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄏ"
-      result: "\\1k’" # HANGUL JONGSEONG KIYEOK + CHOSEONG KHIEUKH
+      result: "\\1k’" # VOWEL + CHOSEONG KHIEUKH
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄐ"
-      result: "\\1t’" # HANGUL JONGSEONG KIYEOK + CHOSEONG THIEUTH
+      result: "\\1t’" # VOWEL + CHOSEONG THIEUTH
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄑ"
-      result: "\\1p’" # HANGUL JONGSEONG KIYEOK + CHOSEONG PHIEUPH
+      result: "\\1p’" # VOWEL + CHOSEONG PHIEUPH
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄒ"
-      result: "\\1h" # HANGUL JONGSEONG KIYEOK + CHOSEONG HIEUH
+      result: "\\1h" # VOWEL + CHOSEONG HIEUH
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄁ"
-      result: "\\1kk" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGKIYEOK
+      result: "\\1kk" # VOWEL + CHOSEONG SSANGKIYEOK
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄄ"
-      result: "\\1tt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIEUT
+      result: "\\1tt" # VOWEL + CHOSEONG SSANGTIEUT
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄈ"
-      result: "\\1pp" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGPIEUP
+      result: "\\1pp" # VOWEL + CHOSEONG SSANGPIEUP
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄊ"
-      result: "\\1ss" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGSIOS
+      result: "\\1ss" # VOWEL + CHOSEONG SSANGSIOS
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])(-?)ᄍ"
-      result: "\\1tch" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGCIEUC
+      result: "\\1tch" # VOWEL + CHOSEONG SSANGCIEUC
     - pattern: "ᆰ(-?)ᄀ"
       result: "l\\1g" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG KIYEOK
     - pattern: "ᆰ(-?)ᄂ"

--- a/maps/kp-kor-Hang-Latn-2002.yaml
+++ b/maps/kp-kor-Hang-Latn-2002.yaml
@@ -1,0 +1,902 @@
+---
+authority_id: kp
+id: 2002
+language: kor
+source_script: Hang
+destination_script: Latn
+name: Korean Democratic People's Republic of Korea Korean System (2002)
+url: https://unstats.un.org/unsd/geoinfo/UNGEGN/docs/8th-uncsgn-docs/inf/8th_UNCSGN_econf.94_INF.72.pdf
+creation_date: 
+adoption_date: 
+description:
+
+notes:
+
+  - Note 3.2
+    The combination n+r is romanized as -ll- only when it is "considered
+    to be longstanding". In this implementation, all n+r is romanized as
+    -ll- for the sake of simplicity.
+
+  - Note 3.3
+    Sai-siot (Connective ㅅ) is not written out in DPRK Korean, but it is
+    supposed to be romanized. Sai-siot is not predictable.
+    This has not been implemented.
+
+  - Note 4.1
+    Hyphen "may be inserted in case of a possible confusion in pronunciation".
+    Except for the n-g combination, this has not been implemented. 
+
+  - Note 4.4
+    Geographical names may be transliterated or translated. In this map, all
+    names will be transliterated, not translated. 
+
+  - Note 4.5
+    Spacing rule for personal names have not been implemented. 
+
+  - Note 4.7 
+    Optional omission of diacritics, and simplification of KK, TT, PP, SS, JJ 
+    have not been implemented.
+
+tests:
+  # Note1.5
+  - source: "우리산"
+    expected: "Urisan"
+
+  # Note2.1
+  - source: "교구동"
+    expected: "Kyogu-dong"
+  - source: "초도"
+    expected: "Chodo"
+  - source: "고비리"
+    expected: "Kobi-ri"
+  - source: "강동"
+    expected: "Kangdong"
+  - source: "금교"
+    expected: "Kümgyo"
+  - source: "칠보산"
+    expected: "Chilbosan"
+
+  # Note2.2
+  - source: "곡산"
+    expected: "Koksan"
+  - source: "갑산"
+    expected: "Kapsan"
+  - source: "앞산"
+    expected: "Apsan"
+  - source: "삿갓봉"
+    expected: "Satkatbong"
+
+  # Note2.3
+  - source: "울산"
+    expected: "Ulsan"
+  # - source: "은률"
+  #   expected: "Ünryul" # This is an exceptino to note 3.1
+
+  # Note2.4
+  - source: "닭섬"
+    expected: "Taksŏm"
+  - source: "물곬"
+    expected: "Mulkol"
+  - source: "붉은바위"
+    expected: "Pulgünbawi"
+  - source: "앉은바위"
+    expected: "Anjünbawi"
+
+  # Note3.1
+  - source: "백마산"
+    expected: "Paengmasan"
+  - source: "꽃마을"
+    expected: "Kkonmaül"
+  - source: "압록강"
+    expected: "Amrokgang"
+
+  # Note3.2
+  - source: "천리마"
+    expected: "Chŏllima"
+  # - source: "한나산"  # Typo in the original document
+  - source: "한라산"  
+    expected: "Hallasan"
+  - source: "전라도"
+    expected: "Jŏlla-do"
+
+  # Note3.3
+  # The issue here is that in DPRK standard orthography, 
+  # 
+  # 
+  # See this page:
+  # https://en.wikipedia.org/wiki/North%E2%80%93South_differences_in_the_Korean_language#Sai_siot_(%EC%82%AC%EC%9D%B4_%EC%8B%9C%EC%98%B7,_%22middle_%E3%85%85%22)
+
+  # - source: "기대산"   # ROK: 깃대산 
+  #   expected: "Kittaesan"
+  # - source: "새별읍"   # ROK: 샛별
+  #   expected: "Saeppyŏl-üp"  # hyphen 
+  # - source: "뒤문"    # ROK: 뒷문
+  #   expected: "Twinmun"
+
+  # Note4.1 - Separator (OPTIONAL)
+
+  - source: "앞-언덕"
+    expected: "Ap-ŏndŏk"
+  - source: "부억-안골"
+    expected: "Puŏk-angol"
+  - source: "판교"
+    expected: "Phan-gyo"
+  # - source: "방어동"
+  #   expected: "Pang-ŏ-dong"
+
+  # Note4.2
+  - source: "평안남도 평성시"
+    expected: "Phyŏngannam-do Phyŏngsŏng-si"
+
+  # Note4.3
+  - source: "3.1동"
+    expected: "3.1-dong"
+
+  # Note4.6
+  - source: "평양"
+    expected: "Pyongyang"
+
+map:
+  character_separator: ""
+  word_separator: " "
+  title_case: True
+  extend: "nil-kor-Hang-Hang-jamo"
+
+  rules:
+
+    # This system does not require transliteration of numerals
+    # convert numbers to space + Hangul
+    # - pattern: "([^0-9 ])(?=[0-9])"
+    #   result: "\\1 "      
+    # - pattern: "1"
+    #   result: "일"
+    # - pattern: "2"
+    #   result: "이"
+    # - pattern: "3"
+    #   result: "삼"
+    # - pattern: "4"
+    #   result: "사"
+    # - pattern: "5"
+    #   result: "오"
+    # - pattern: "6"
+    #   result: "육"
+    # - pattern: "7"
+    #   result: "칠"
+    # - pattern: "8"
+    #   result: "팔"
+    # - pattern: "9"
+    #   result: "구"
+
+    # Use voiced onset for geographical features
+    # Note 4.3.1
+    - pattern: "(?<=..)산( |$)"
+      result: "san\\1"
+    - pattern: "(?<=..)거리( |$)"
+      result: "gŏri\\1"
+    - pattern: "(?<=..)고개( |$)"
+      result: "gogae\\1"
+    - pattern: "(?<=..)대( |$)"
+      result: "dae\\1"
+    - pattern: "(?<=..)봉( |$)"
+      result: "bong\\1"
+    - pattern: "(?<=..)교( |$)"
+      result: "gyo\\1"
+    - pattern: "(?<=..)골( |$)"
+      result: "gol\\1"
+    - pattern: "(?<=..)각( |$)"
+      result: "gak\\1"
+    - pattern: "(?<=..)벌( |$)"
+      result: "bŏl\\1"
+    - pattern: "(?<=..)관( |$)"
+      result: "gwan\\1"
+    - pattern: "(?<=..)곶( |$)"
+      result: "got\\1"
+    - pattern: "(?<=..)강( |$)"
+      result: "gang\\1"
+
+    # add hyphen in front of generics
+    # Only add hyphen if the name is three syllables or longer
+    - pattern: "(?<=..)도( |$)"
+      result: "-do\\1"
+    - pattern: "(?<=..)시( |$)"
+      result: "-si\\1"
+    - pattern: "(?<=..)군( |$)"
+      result: "-gun\\1"
+    - pattern: "(?<=..)면( |$)"
+      result: "-myŏn\\1"
+    - pattern: "(?<=..)리( |$)"
+      result: "-ri\\1"
+    - pattern: "(?<=..)동( |$)"
+      result: "-dong\\1"
+    - pattern: "(?<=..)구( |$)"
+      result: "-gu\\1"
+    - pattern: "(?<=..)구역( |$)"
+      result: "-guyŏk\\1"
+
+    # The name Pyongyang will be an exception
+    # Not Phyŏngyang
+
+    - pattern: "평양"
+      result: "Pyongyang"
+
+  postrules:
+
+    # Add space to the two ends of the string for easier word boundary handling
+    - pattern: "^"
+      result: " "
+    - pattern: "$"
+      result: " "
+
+    # HANGUL JONGSEONG SSANGKIYEOK
+    - pattern: "ᆩᄋ"
+      result: "ᆨᄁ"
+    - pattern: "ᆩ"
+      result: "ᆨ"
+
+    # HANGUL JONGSEONG SSANGKIYEOK
+    - pattern: "ᆪᄋ"
+      result: "ᆨᄉ"
+    - pattern: "ᆪ"
+      result: "ᆨ"
+
+    # HANGUL JONGSEONG NIEUN-CIEUC
+    - pattern: "ᆬᄋ"
+      result: "ᆫᄌ"
+    - pattern: "ᆬ"
+      result: "ᆫ"
+
+    # HANGUL JONGSEONG NIEUN-CIEUC
+    - pattern: "ᆭᄀ"
+      result: "ᆫᄏ"
+    - pattern: "ᆭᄃ"
+      result: "ᆫᄐ"
+    - pattern: "ᆭᄇ"
+      result: "ᆫᄑ"
+    - pattern: "ᆭᄌ"
+      result: "ᆫᄎ"
+    - pattern: "ᆭ"
+      result: "ᆫ"
+
+    # HANGUL JONGSEONG TIEUT
+    - pattern: "ᆮ(?=[ᄀᄁᄂᄃᄄᄅᄆᄇᄈᄉᄊᄌᄍᄎᄏᄐᄑᄒ])"
+      result: "ᆺ"
+
+    # HANGUL JONGSEONG RIEUL-SIOS
+    - pattern: "ᆳᄋ"
+      result: "ᆯᄉ"
+    - pattern: "ᆳ"
+      result: "ᆯ"
+
+    # HANGUL JONGSEONG RIEUL-THIEUTH
+    - pattern: "ᆴᄋ"
+      result: "ᆯᄐ"
+    - pattern: "ᆴ"
+      result: "ᆯ"
+
+    # HANGUL JONGSEONG RIEUL-PHIEUPH
+    - pattern: "ᆵᄋ"
+      result: "ᆯᄑ"
+    - pattern: "ᆵ(?=[ᄃᄄᄐ])"
+      result: "ᆯ"
+    - pattern: "ᆵ"
+      result: "ᄇ"
+
+    # HANGUL JONGSEONG RIEUL-HIEUH
+    - pattern: "ᆶᄀ"
+      result: "ᆯᄏ"
+    - pattern: "ᆶᄃ"
+      result: "ᆯᄐ"
+    - pattern: "ᆶᄇ"
+      result: "ᆯᄑ"
+    - pattern: "ᆶᄌ"
+      result: "ᆯᄎ"
+    - pattern: "ᆶ"
+      result: "ᆯ"
+    
+    # HANGUL JONGSEONG PIEUP-SIOS
+    - pattern: "ᆹᄋ"
+      result: "ᄇᄉ"
+    - pattern: "ᆹ"
+      result: "ᄇ"
+
+    # HANGUL JONGSEONG SSANG-SIOS
+    - pattern: "ᆻᄋ"
+      result: "ᆺᄊ"
+    - pattern: "ᆻ"
+      result: "ᆺ"
+    
+    # HANGUL JONGSEONG CIEUC
+    - pattern: "ᆽᄋ"
+      result: "ᆺᄌ"
+    - pattern: "ᆽ"
+      result: "ᆺ"
+
+    # HANGUL JONGSEONG CHIEUCH
+    - pattern: "ᆾᄋ"
+      result: "ᆺᄎ"
+    - pattern: "ᆾ"
+      result: "ᆺ"
+
+    # HANGUL JONGSEONG KHIEUKH
+    - pattern: "ᆿᄋ"
+      result: "ᆨᄏ"
+    - pattern: "ᆿ"
+      result: "ᆨ"
+
+    # HANGUL JONGSEONG THIEUTH
+    - pattern: "ᇀᄋ"
+      result: "ᆺᄐ"
+    - pattern: "ᇀ"
+      result: "ᆺ"
+
+    # HANGUL JONGSEONG PHIEUPH
+    - pattern: "ᇁᄋ"
+      result: "ᆸᄑ"
+    - pattern: "ᇁ"
+      result: "ᆸ"
+
+    # HANGUL JONGSEONG HIEUH
+    - pattern: "ᇂᄀ"
+      result: "ᄏ"
+    - pattern: "ᇂᄃ"
+      result: "ᄐ"
+    - pattern: "ᇂᄇ"
+      result: "ᄑ"
+    - pattern: "ᇂᄌ"
+      result: "ᄎ"
+    - pattern: "ᇂ"
+      result: ""
+
+    # From Unicode Chart
+    # https://github.com/unicode-org/cldr/blob/master/common/transforms/Korean-Latin-BGN.xml
+    - pattern: "ᆨᄀ"
+      result: "kk" # HANGUL JONGSEONG KIYEOK + CHOSEONG KIYEOK
+    - pattern: "ᆨᄂ"
+      result: "ngn" # HANGUL JONGSEONG KIYEOK + CHOSEONG NIEUN
+    - pattern: "ᆨᄃ"
+      result: "kt" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIEUT
+    - pattern: "ᆨᄅ"
+      result: "ngn" # HANGUL JONGSEONG KIYEOK + CHOSEONG RIEUL
+    - pattern: "ᆨᄆ"
+      result: "ngm" # HANGUL JONGSEONG KIYEOK + CHOSEONG MIEUM
+    - pattern: "ᆨᄇ"
+      result: "kp" # HANGUL JONGSEONG KIYEOK + CHOSEONG PIEUP
+    - pattern: "ᆨᄉ"
+      result: "ks" # HANGUL JONGSEONG KIYEOK + CHOSEONG SIOS
+    - pattern: "ᆨᄋ"
+      result: "g" # HANGUL JONGSEONG KIYEOK + CHOSEONG IEUNG
+    - pattern: "ᆨᄌ"
+      result: "kj" # HANGUL JONGSEONG KIYEOK + CHOSEONG CIEUC
+    - pattern: "ᆨᄎ"
+      result: "kch" # HANGUL JONGSEONG KIYEOK + CHOSEONG CHIEUCH
+    - pattern: "ᆨᄏ"
+      result: "kkh" # HANGUL JONGSEONG KIYEOK + CHOSEONG KHIEUKH # NOTE: the dash is always skipped
+    - pattern: "ᆨᄐ"
+      result: "kth" # HANGUL JONGSEONG KIYEOK + CHOSEONG THIEUTH
+    - pattern: "ᆨᄑ"
+      result: "kp" # HANGUL JONGSEONG KIYEOK + CHOSEONG PHIEUPH
+    - pattern: "ᆨᄒ"
+      result: "kh" # HANGUL JONGSEONG KIYEOK + CHOSEONG HIEUH
+    - pattern: "ᆨᄁ"
+      result: "kkk" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆨᄄ"
+      result: "ktt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIEUT
+    - pattern: "ᆨᄈ"
+      result: "kpp" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGPIEUP
+    - pattern: "ᆨᄊ"
+      result: "kss" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGSIOS
+    - pattern: "ᆨᄍ"
+      result: "kjj" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGCIEUC
+    - pattern: "ᆫᄀ"
+      result: "n-g" # HANGUL JONGSEONG NIEUN + CHOSEONG KIEUK
+    - pattern: "ᆫᄂ"
+      result: "nn" # HANGUL JONGSEONG NIEUN + CHOSEONG NIEUN
+    - pattern: "ᆫᄃ"
+      result: "nd" # HANGUL JONGSEONG NIEUN + CHOSEONG TIEUT
+    - pattern: "ᆫᄅ"
+      result: "ll" # HANGUL JONGSEONG NIEUN + CHOSEONG RIEUL
+    - pattern: "ᆫᄆ"
+      result: "nm" # HANGUL JONGSEONG NIEUN + CHOSEONG MIEUM
+    - pattern: "ᆫᄇ"
+      result: "nb" # HANGUL JONGSEONG NIEUN + CHOSEONG PIEUP
+    - pattern: "ᆫᄉ"
+      result: "ns" # HANGUL JONGSEONG NIEUN + CHOSEONG SIOS
+    - pattern: "ᆫᄋ"
+      result: "n" # HANGUL JONGSEONG NIEUN + CHOSEONG IEUNG
+    - pattern: "ᆫᄌ"
+      result: "nj" # HANGUL JONGSEONG NIEUN + CHOSEONG CIEUC
+    - pattern: "ᆫᄎ"
+      result: "nch" # HANGUL JONGSEONG NIEUN + CHOSEONG CHIEUCH
+    - pattern: "ᆫᄏ"
+      result: "nkh" # HANGUL JONGSEONG NIEUN + CHOSEONG KHIEUKH
+    - pattern: "ᆫᄐ"
+      result: "nth" # HANGUL JONGSEONG NIEUN + CHOSEONG THIEUTH
+    - pattern: "ᆫᄑ"
+      result: "nph" # HANGUL JONGSEONG NIEUN + CHOSEONG PHIEUPH
+    - pattern: "ᆫᄒ"
+      result: "nh" # HANGUL JONGSEONG NIEUN + CHOSEONG HIEUH
+    - pattern: "ᆫᄁ"
+      result: "nkk" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆫᄄ"
+      result: "ntt" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGTIEUT
+    - pattern: "ᆫᄈ"
+      result: "npp" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGPIEUP
+    - pattern: "ᆫᄊ"
+      result: "nss" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGSIOS
+    - pattern: "ᆫᄍ"
+      result: "njj" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGCIEUC
+    - pattern: "ᆯᄀ"
+      result: "lk" # HANGUL JONGSEONG RIEUL + CHOSEONG KIYEOK
+    - pattern: "ᆯᄂ"
+      result: "ll" # HANGUL JONGSEONG RIEUL + CHOSEONG NIEUN
+    - pattern: "ᆯᄃ"
+      result: "lt" # HANGUL JONGSEONG RIEUL + CHOSEONG TIEUT
+    - pattern: "ᆯᄅ"
+      result: "ll" # HANGUL JONGSEONG RIEUL + CHOSEONG RIEUL
+    - pattern: "ᆯᄆ"
+      result: "lm" # HANGUL JONGSEONG RIEUL + CHOSEONG MIEUM
+    - pattern: "ᆯᄇ"
+      result: "lb" # HANGUL JONGSEONG RIEUL + CHOSEONG PIEUP
+    - pattern: "ᆯᄉ"
+      result: "ls" # HANGUL JONGSEONG RIEUL + CHOSEONG SIOS
+    - pattern: "ᆯᄋ"
+      result: "r" # HANGUL JONGSEONG RIEUL + CHOSEONG IEUNG
+    - pattern: "ᆯᄌ"
+      result: "lj" # HANGUL JONGSEONG RIEUL + CHOSEONG CIEUC
+    - pattern: "ᆯᄎ"
+      result: "lch" # HANGUL JONGSEONG RIEUL + CHOSEONG CHIEUCH
+    - pattern: "ᆯᄏ"
+      result: "lkh" # HANGUL JONGSEONG RIEUL + CHOSEONG KHIEUKH
+    - pattern: "ᆯᄐ"
+      result: "lth" # HANGUL JONGSEONG RIEUL + CHOSEONG THIEUTH
+    - pattern: "ᆯᄑ"
+      result: "lph" # HANGUL JONGSEONG RIEUL + CHOSEONG PHIEUPH
+    - pattern: "ᆯᄒ"
+      result: "lh" # HANGUL JONGSEONG RIEUL + CHOSEONG HIEUH
+    - pattern: "ᆯᄁ"
+      result: "lkk" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆯᄄ"
+      result: "ltt" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGTIEUT
+    - pattern: "ᆯᄈ"
+      result: "lpp" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGPIEUP
+    - pattern: "ᆯᄊ"
+      result: "lss" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGSIOS
+    - pattern: "ᆯᄍ"
+      result: "ljj" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGCIEUC
+    - pattern: "ᆷᄀ"
+      result: "mg" # HANGUL JONGSEONG MIEUM + CHOSEONG KIYEOK
+    - pattern: "ᆷᄂ"
+      result: "mn" # HANGUL JONGSEONG MIEUM + CHOSEONG NIEUN
+    - pattern: "ᆷᄃ"
+      result: "md" # HANGUL JONGSEONG MIEUM + CHOSEONG TIEUT
+    - pattern: "ᆷᄅ"
+      result: "mr" # HANGUL JONGSEONG MIEUM + CHOSEONG RIEUL  # Note 3.1
+    - pattern: "ᆷᄆ"
+      result: "mm" # HANGUL JONGSEONG MIEUM + CHOSEONG MIEUM
+    - pattern: "ᆷᄇ"
+      result: "mb" # HANGUL JONGSEONG MIEUM + CHOSEONG PIEUP
+    - pattern: "ᆷᄉ"
+      result: "ms" # HANGUL JONGSEONG MIEUM + CHOSEONG SIOS
+    - pattern: "ᆷᄋ"
+      result: "m" # HANGUL JONGSEONG MIEUM + CHOSEONG IEUNG
+    - pattern: "ᆷᄌ"
+      result: "mj" # HANGUL JONGSEONG MIEUM + CHOSEONG CIEUC
+    - pattern: "ᆷᄎ"
+      result: "mch" # HANGUL JONGSEONG MIEUM + CHOSEONG CHIEUCH
+    - pattern: "ᆷᄏ"
+      result: "mkh" # HANGUL JONGSEONG MIEUM + CHOSEONG KHIEUKH
+    - pattern: "ᆷᄐ"
+      result: "mth" # HANGUL JONGSEONG MIEUM + CHOSEONG THIEUTH
+    - pattern: "ᆷᄑ"
+      result: "mph" # HANGUL JONGSEONG MIEUM + CHOSEONG PHIEUPH
+    - pattern: "ᆷᄒ"
+      result: "mh" # HANGUL JONGSEONG MIEUM + CHOSEONG HIEUH
+    - pattern: "ᆷᄁ"
+      result: "mkk" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆷᄄ"
+      result: "mtt" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGTIEUT
+    - pattern: "ᆷᄈ"
+      result: "mpp" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGPIEUP
+    - pattern: "ᆷᄊ"
+      result: "mss" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGSIOS
+    - pattern: "ᆷᄍ"
+      result: "mjj" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGCIEUC
+    - pattern: "ᆸᄀ"
+      result: "pk" # HANGUL JONGSEONG PIEUP + CHOSEONG KIYEOK
+    - pattern: "ᆸᄂ"
+      result: "mn" # HANGUL JONGSEONG PIEUP + CHOSEONG NIEUN
+    - pattern: "ᆸᄃ"
+      result: "pt" # HANGUL JONGSEONG PIEUP + CHOSEONG TIEUT
+    - pattern: "ᆸᄅ"
+      result: "mr" # HANGUL JONGSEONG PIEUP + CHOSEONG RIEUL
+    - pattern: "ᆸᄆ"
+      result: "mm" # HANGUL JONGSEONG PIEUP + CHOSEONG MIEUM
+    - pattern: "ᆸᄇ"
+      result: "pp" # HANGUL JONGSEONG PIEUP + CHOSEONG PIEUP
+    - pattern: "ᆸᄉ"
+      result: "ps" # HANGUL JONGSEONG PIEUP + CHOSEONG SIOS
+    - pattern: "ᆸᄋ"
+      result: "b" # HANGUL JONGSEONG PIEUP + CHOSEONG IEUNG
+    - pattern: "ᆸᄌ"
+      result: "pj" # HANGUL JONGSEONG PIEUP + CHOSEONG CIEUC
+    - pattern: "ᆸᄎ"
+      result: "pch" # HANGUL JONGSEONG PIEUP + CHOSEONG CHIEUCH
+    - pattern: "ᆸᄏ"
+      result: "pkh" # HANGUL JONGSEONG PIEUP + CHOSEONG KHIEUKH
+    - pattern: "ᆸᄐ"
+      result: "pth" # HANGUL JONGSEONG PIEUP + CHOSEONG THIEUTH
+    - pattern: "ᆸᄑ"
+      result: "pph" # HANGUL JONGSEONG PIEUP + CHOSEONG PHIEUPH
+    - pattern: "ᆸᄒ"
+      result: "ph" # HANGUL JONGSEONG PIEUP + CHOSEONG HIEUH
+    - pattern: "ᆸᄁ"
+      result: "pkk" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆸᄄ"
+      result: "ptt" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGTIEUT
+    - pattern: "ᆸᄈ"
+      result: "ppp" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGPIEUP
+    - pattern: "ᆸᄊ"
+      result: "pss" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGSIOS
+    - pattern: "ᆸᄍ"
+      result: "pjj" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGCIEUC
+    - pattern: "ᆺᄀ"
+      result: "tk" # HANGUL JONGSEONG SIOS + CHOSEONG KIYEOK
+    - pattern: "ᆺᄂ"
+      result: "nn" # HANGUL JONGSEONG SIOS + CHOSEONG NIEUN
+    - pattern: "ᆺᄃ"
+      result: "tt" # HANGUL JONGSEONG SIOS + CHOSEONG TIEUT
+    - pattern: "ᆺᄅ"
+      result: "nr" # HANGUL JONGSEONG SIOS + CHOSEONG RIEUL  # Note 3.1
+    - pattern: "ᆺᄆ"
+      result: "nm" # HANGUL JONGSEONG SIOS + CHOSEONG MIEUM
+    - pattern: "ᆺᄇ"
+      result: "tp" # HANGUL JONGSEONG SIOS + CHOSEONG PIEUP
+    - pattern: "ᆺᄉ"
+      result: "ts" # HANGUL JONGSEONG SIOS + CHOSEONG SIOS
+    - pattern: "ᆺᄋ"
+      result: "d" # HANGUL JONGSEONG SIOS + CHOSEONG IEUNG
+    - pattern: "ᆺᄌ"
+      result: "tj" # HANGUL JONGSEONG SIOS + CHOSEONG CIEUC
+    - pattern: "ᆺᄎ"
+      result: "tch" # HANGUL JONGSEONG SIOS + CHOSEONG CHIEUCH
+    - pattern: "ᆺᄏ"
+      result: "tkh" # HANGUL JONGSEONG SIOS + CHOSEONG KHIEUKH
+    - pattern: "ᆺᄐ"
+      result: "tth" # HANGUL JONGSEONG SIOS + CHOSEONG THIEUTH
+    - pattern: "ᆺᄑ"
+      result: "tph" # HANGUL JONGSEONG SIOS + CHOSEONG PHIEUPH
+    - pattern: "ᆺᄒ"
+      result: "th" # HANGUL JONGSEONG SIOS + CHOSEONG HIEUH
+    - pattern: "ᆺᄁ"
+      result: "tkk" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆺᄄ"
+      result: "ttt" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGTIEUT
+    - pattern: "ᆺᄈ"
+      result: "tpp" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGPIEUP
+    - pattern: "ᆺᄊ"
+      result: "tss" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGSIOS
+    - pattern: "ᆺᄍ"
+      result: "tjj" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGCIEUC
+    - pattern: "ᆼᄀ"
+      result: "ngg" # HANGUL JONGSEONG IEUNG + CHOSEONG KIYEOK
+    - pattern: "ᆼᄂ"
+      result: "ngn" # HANGUL JONGSEONG IEUNG + CHOSEONG NIEUN
+    - pattern: "ᆼᄃ"
+      result: "ngd" # HANGUL JONGSEONG IEUNG + CHOSEONG TIEUT
+    - pattern: "ᆼᄅ"
+      result: "ngn" # HANGUL JONGSEONG IEUNG + CHOSEONG RIEUL
+    - pattern: "ᆼᄆ"
+      result: "ngm" # HANGUL JONGSEONG IEUNG + CHOSEONG MIEUM
+    - pattern: "ᆼᄇ"
+      result: "ngb" # HANGUL JONGSEONG IEUNG + CHOSEONG PIEUP
+    - pattern: "ᆼᄉ"
+      result: "ngs" # HANGUL JONGSEONG IEUNG + CHOSEONG SIOS
+    - pattern: "ᆼᄋ"
+      result: "ng" # HANGUL JONGSEONG IEUNG + CHOSEONG IEUNG
+    - pattern: "ᆼᄌ"
+      result: "ngj" # HANGUL JONGSEONG IEUNG + CHOSEONG CIEUC
+    - pattern: "ᆼᄎ"
+      result: "ngch" # HANGUL JONGSEONG IEUNG + CHOSEONG CHIEUCH
+    - pattern: "ᆼᄏ"
+      result: "ngkh" # HANGUL JONGSEONG IEUNG + CHOSEONG KHIEUKH
+    - pattern: "ᆼᄐ"
+      result: "ngth" # HANGUL JONGSEONG IEUNG + CHOSEONG THIEUTH
+    - pattern: "ᆼᄑ"
+      result: "ngph" # HANGUL JONGSEONG IEUNG + CHOSEONG PHIEUPH
+    - pattern: "ᆼᄒ"
+      result: "ngh" # HANGUL JONGSEONG IEUNG + CHOSEONG HIEUH
+    - pattern: "ᆼᄁ"
+      result: "ngkk" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆼᄄ"
+      result: "ngtt" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGTIEUT
+    - pattern: "ᆼᄈ"
+      result: "ngpp" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGPIEUP
+    - pattern: "ᆼᄊ"
+      result: "ngss" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGSIOS
+    - pattern: "ᆼᄍ"
+      result: "ngjj" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGCIEUC
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄀ"
+      result: "g" # VOWEL + CHOSEONG KIYEOK # c.f. Note 3.3
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄂ"
+      result: "n" # VOWEL + CHOSEONG NIEUN # c.f. Note 3.3
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄃ"
+      result: "d" # VOWEL + CHOSEONG TIEUT # c.f. Note 3.3
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄅ"
+      result: "r" # VOWEL + CHOSEONG RIEUL
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄆ"
+      result: "m" # VOWEL + CHOSEONG MIEUM # c.f. Note 3.3
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄇ"
+      result: "b" # VOWEL + CHOSEONG PIEUP # c.f. Note 3.3
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄉ"
+      result: "s" # VOWEL + CHOSEONG SIOS
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄋ"
+      result: "" # VOWEL + CHOSEONG IEUNG
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄌ"
+      result: "j" # VOWEL + CHOSEONG CIEUC
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄎ"
+      result: "ch" # VOWEL + CHOSEONG CHIEUCH
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄏ"
+      result: "kh" # VOWEL + CHOSEONG KHIEUKH
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄐ"
+      result: "th" # VOWEL + CHOSEONG THIEUTH
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄑ"
+      result: "ph" # VOWEL + CHOSEONG PHIEUPH
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄒ"
+      result: "h" # VOWEL + CHOSEONG HIEUH
+    - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄁ"
+      result: "kk" # VOWEL + CHOSEONG SSANGKIYEOK
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄄ"
+      result: "tt" # VOWEL + CHOSEONG SSANGTIEUT
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄈ"
+      result: "pp" # VOWEL + CHOSEONG SSANGPIEUP
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄊ"
+      result: "ss" # VOWEL + CHOSEONG SSANGSIOS
+    - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄍ"
+      result: "jj" # VOWEL + CHOSEONG SSANGCIEUC
+    - pattern: "ᆰᄀ"
+      result: "lg" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG KIYEOK
+    - pattern: "ᆰᄂ"
+      result: "ngn" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG NIEUN
+    - pattern: "ᆰᄃ"
+      result: "kt" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG TIEUT
+    - pattern: "ᆰᄅ"
+      result: "ngn" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG RIEUL
+    - pattern: "ᆰᄆ"
+      result: "ngm" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG MIEUM
+    - pattern: "ᆰᄇ"
+      result: "kp" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG PIEUP
+    - pattern: "ᆰᄉ"
+      result: "ks" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SIOS
+    - pattern: "ᆰᄋ"
+      result: "lg" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG IEUNG
+    - pattern: "ᆰᄌ"
+      result: "kj" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG CIEUC
+    - pattern: "ᆰᄎ"
+      result: "kch" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG CHIEUCH
+    - pattern: "ᆰᄏ"
+      result: "lkh" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG KHIEUKH
+    - pattern: "ᆰᄐ"
+      result: "kth" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG THIEUTH
+    - pattern: "ᆰᄑ"
+      result: "kph" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG PHIEUPH
+    - pattern: "ᆰᄒ"
+      result: "lkh" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG HIEUH
+    - pattern: "ᆰᄁ"
+      result: "lkk" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆰᄄ"
+      result: "ktt" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGTIEUT
+    - pattern: "ᆰᄈ"
+      result: "kpp" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGPIEUP
+    - pattern: "ᆰᄊ"
+      result: "kss" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGSIOS
+    - pattern: "ᆰᄍ"
+      result: "kjj" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGCIEUC
+    - pattern: "ᆱᄀ"
+      result: "mg" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG KIYEOK
+    - pattern: "ᆱᄂ"
+      result: "mn" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG NIEUN
+    - pattern: "ᆱᄃ"
+      result: "md" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG TIEUT
+    - pattern: "ᆱᄅ"
+      result: "mr" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG RIEUL
+    - pattern: "ᆱᄆ"
+      result: "lm" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG MIEUM
+    - pattern: "ᆱᄇ"
+      result: "mb" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG PIEUP
+    - pattern: "ᆱᄉ"
+      result: "ms" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SIOS
+    - pattern: "ᆱᄋ"
+      result: "lm" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG IEUNG
+    - pattern: "ᆱᄌ"
+      result: "mj" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG CIEUC
+    - pattern: "ᆱᄎ"
+      result: "mch" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG CHIEUCH
+    - pattern: "ᆱᄏ"
+      result: "mkh" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG KHIEUKH
+    - pattern: "ᆱᄐ"
+      result: "mth" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG THIEUTH
+    - pattern: "ᆱᄑ"
+      result: "mph" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG PHIEUPH
+    - pattern: "ᆱᄒ"
+      result: "mh" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG HIEUH
+    - pattern: "ᆱᄁ"
+      result: "mkk" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆱᄄ"
+      result: "mtt" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGTIEUT
+    - pattern: "ᆱᄈ"
+      result: "mpp" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGPIEUP
+    - pattern: "ᆱᄊ"
+      result: "mss" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGSIOS
+    - pattern: "ᆱᄍ"
+      result: "mjj" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGCIEUC
+    - pattern: "ᆲᄀ"
+      result: "pk" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG KIYEOK
+    - pattern: "ᆲᄂ"
+      result: "mn" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG NIEUN
+    - pattern: "ᆲᄃ"
+      result: "pt" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG TIEUT
+    - pattern: "ᆲᄅ"
+      result: "mr" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG RIEUL
+    - pattern: "ᆲᄆ"
+      result: "mm" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG MIEUM
+    - pattern: "ᆲᄇ"
+      result: "lb" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG PIEUP
+    - pattern: "ᆲᄉ"
+      result: "ps" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SIOS
+    - pattern: "ᆲᄋ"
+      result: "lb" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG IEUNG
+    - pattern: "ᆲᄌ"
+      result: "pj" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG CIEUC
+    - pattern: "ᆲᄎ"
+      result: "pch" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG CHIEUCH
+    - pattern: "ᆲᄏ"
+      result: "pkh" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG KHIEUKH
+    - pattern: "ᆲᄐ"
+      result: "pth" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG THIEUTH
+    - pattern: "ᆲᄑ"
+      result: "lph" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG PHIEUPH
+    - pattern: "ᆲᄒ"
+      result: "lph" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG HIEUH
+    - pattern: "ᆲᄁ"
+      result: "pkk" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGKIYEOK
+    - pattern: "ᆲᄄ"
+      result: "ptt" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGTIEUT
+    - pattern: "ᆲᄈ"
+      result: "lpp" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGPIEUP
+    - pattern: "ᆲᄊ"
+      result: "pss" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGSIOS
+    - pattern: "ᆲᄍ"
+      result: "pjj" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGCIEUC
+    - pattern: "(?<= )ᄀ"
+      result: "k" # HANGUL CHOSEONG KIYEOK
+    - pattern: "(?<= )ᄂ"
+      result: "n" # HANGUL CHOSEONG NIEUN
+    - pattern: "(?<= )ᄃ"
+      result: "t" # HANGUL CHOSEONG TIEUT
+
+    # DPRK does not follow the R-onset rule
+    # - pattern: "(?<= )ᄅ(?=[ᅣᅤᅧᅨᅭᅲ])"
+    #   result: "" # HANGUL CHOSEONG RIEUL # R-onset rule
+    - pattern: "(?<= )ᄅ"
+    # result: "n" # HANGUL CHOSEONG RIEUL
+      result: "r"
+
+    - pattern: "(?<= )ᄆ"
+      result: "m" # HANGUL CHOSEONG MIEUM
+    - pattern: "(?<= )ᄇ"
+      result: "p" # HANGUL CHOSEONG PIEUP
+    - pattern: "(?<= )ᄉ"
+      result: "s" # HANGUL CHOSEONG SIOS
+    - pattern: "(?<= )ᄋ"
+      result: "" # HANGUL CHOSEONG IEUNG
+    - pattern: "(?<= )ᄌ"
+      result: "j" # HANGUL CHOSEONG CIEUC
+    - pattern: "(?<= )ᄎ"
+      result: "ch" # HANGUL CHOSEONG CHIEUCH
+    - pattern: "(?<= )ᄏ"
+      result: "kh" # HANGUL CHOSEONG KHIEUKH
+    - pattern: "(?<= )ᄐ"
+      result: "th" # HANGUL CHOSEONG THIEUTH
+    - pattern: "(?<= )ᄑ"
+      result: "ph" # HANGUL CHOSEONG PHIEUPH
+    - pattern: "(?<= )ᄒ"
+      result: "h" # HANGUL CHOSEONG HIEUH
+    - pattern: "(?<= )ᄁ"
+      result: "kk" # HANGUL CHOSEONG SSANGKIYEOK
+    - pattern: "(?<= )ᄭ"
+      result: "kk" # HANGUL CHOSEONG SIOS-KIYEOK
+    - pattern: "(?<= )ᄄ"
+      result: "tt" # HANGUL CHOSEONG SSANGTIEUT
+    - pattern: "(?<= )ᄯ"
+      result: "tt" # HANGUL CHOSEONG SIOS-TIEUT
+    - pattern: "(?<= )ᄈ"
+      result: "pp" # HANGUL CHOSEONG SSANGPIEUP
+    - pattern: "(?<= )ᄲ"
+      result: "pp" # HANGUL CHOSEONG SIOS-PIEUP
+    - pattern: "(?<= )ᄊ"
+      result: "ss" # HANGUL CHOSEONG SSANGSIOS
+    - pattern: "(?<= )ᄍ"
+      result: "jj" # HANGUL CHOSEONG SSANGCIEUC
+    - pattern: "(?<= )ᄶ"
+      result: "jj" # HANGUL CHOSEONG SIOS-CIEUC
+    - pattern: "ᅡ"
+      result: "a" # HANGUL JUNGSEONG A
+    - pattern: "ᅣ"
+      result: "ya" # HANGUL JUNGSEONG YA
+    - pattern: "ᅥ"
+      result: "ŏ" # HANGUL JUNGSEONG EO
+    - pattern: "ᅧ"
+      result: "yŏ" # HANGUL JUNGSEONG YEO
+    - pattern: "ᅩ"
+      result: "o" # HANGUL JUNGSEONG O
+    - pattern: "ᅭ"
+      result: "yo" # HANGUL JUNGSEONG YO
+    - pattern: "ᅮ"
+      result: "u" # HANGUL JUNGSEONG U
+    - pattern: "ᅲ"
+      result: "yu" # HANGUL JUNGSEONG YU
+    - pattern: "ᅳ"
+      result: "ü" # HANGUL JUNGSEONG EU
+    - pattern: "ᅵ"
+      result: "i" # HANGUL JUNGSEONG I
+    - pattern: "ᅢ"
+      result: "ae" # HANGUL JUNGSEONG AE
+    - pattern: "ᅤ"
+      result: "yae" # HANGUL JUNGSEONG YAE
+    - pattern: "ᅦ"
+      result: "e" # HANGUL JUNGSEONG E
+    - pattern: "ᅨ"
+      result: "ye" # HANGUL JUNGSEONG YE
+    - pattern: "ᅬ"
+      result: "oe" # HANGUL JUNGSEONG OE
+    - pattern: "ᅱ"
+      result: "wi" # HANGUL JUNGSEONG WI
+    - pattern: "ᅴ"
+      result: "üi" # HANGUL JUNGSEONG YI
+    - pattern: "ᅪ"
+      result: "wa" # HANGUL JUNGSEONG WA
+    - pattern: "ᅯ"
+      result: "wo" # HANGUL JUNGSEONG WEO
+    - pattern: "ᅫ"
+      result: "wae" # HANGUL JUNGSEONG WAE
+    - pattern: "ᅰ"
+      result: "we" # HANGUL JUNGSEONG WE
+    - pattern: "ᆨ(?=[ A-Za-z0-9-])"
+      result: "k" # HANGUL JONGSEONG KIYEOK
+    - pattern: "ᆫ(?=[ A-Za-z0-9-])"
+      result: "n" # HANGUL JONGSEONG NIEUN
+    - pattern: "ᆮ(?=[ A-Za-z0-9-])"
+      result: "t" # HANGUL JONGSEONG TIEUT
+    - pattern: "ᆯ(?=[ A-Za-z0-9-])"
+      result: "l" # HANGUL JONGSEONG RIEUL
+    - pattern: "ᆷ(?=[ A-Za-z0-9-])"
+      result: "m" # HANGUL JONGSEONG MIEUM
+    - pattern: "ᆸ(?=[ A-Za-z0-9-])"
+      result: "p" # HANGUL JONGSEONG PIEUP
+    - pattern: "ᆺ(?=[ A-Za-z0-9-])"
+      result: "t" # HANGUL JONGSEONG SIOS
+    - pattern: "ᆼ(?=[ A-Za-z0-9-])"
+      result: "ng" # HANGUL JONGSEONG IEUNG
+    - pattern: "ᆽ(?=[ A-Za-z0-9-])"
+      result: "t" # HANGUL JONGSEONG CIEUC
+    - pattern: "ᆾ(?=[ A-Za-z0-9-])"
+      result: "t" # HANGUL JONGSEONG CHIEUCH
+    - pattern: "ᆿ(?=[ A-Za-z0-9-])"
+      result: "k" # HANGUL JONGSEONG KHIEUKH
+    - pattern: "ᇀ(?=[ A-Za-z0-9-])"
+      result: "t" # HANGUL JONGSEONG THIEUTH
+    - pattern: "ᇁ(?=[ A-Za-z0-9-])"
+      result: "p" # HANGUL JONGSEONG PHIEUPH
+    - pattern: "ᆰ(?=[ A-Za-z0-9-])"
+      result: "k" # HANGUL JONGSEONG RIEUL-KIYEOK
+    - pattern: "ᆲ(?=[ A-Za-z0-9-])"
+      result: "p" # HANGUL JONGSEONG RIEUL-PIEUP
+
+    # Remove space added
+    - pattern: "^ "
+      result: ""
+    - pattern: " $"
+      result: ""
+
+  characters:
+  # This is based on Jamo

--- a/maps/kp-kor-Hang-Latn-2002.yaml
+++ b/maps/kp-kor-Hang-Latn-2002.yaml
@@ -6,8 +6,8 @@ source_script: Hang
 destination_script: Latn
 name: Korean Democratic People's Republic of Korea Korean System (2002)
 url: https://unstats.un.org/unsd/geoinfo/UNGEGN/docs/8th-uncsgn-docs/inf/8th_UNCSGN_econf.94_INF.72.pdf
-creation_date: 
-adoption_date: 
+creation_date:
+adoption_date:
 description:
 
 notes:
@@ -24,17 +24,17 @@ notes:
 
   - Note 4.1
     Hyphen "may be inserted in case of a possible confusion in pronunciation".
-    Except for the n-g combination, this has not been implemented. 
+    Except for the n-g combination, this has not been implemented.
 
   - Note 4.4
     Geographical names may be transliterated or translated. In this map, all
-    names will be transliterated, not translated. 
+    names will be transliterated, not translated.
 
   - Note 4.5
-    Spacing rule for personal names have not been implemented. 
+    Spacing rule for personal names have not been implemented.
 
-  - Note 4.7 
-    Optional omission of diacritics, and simplification of KK, TT, PP, SS, JJ 
+  - Note 4.7
+    Optional omission of diacritics, and simplification of KK, TT, PP, SS, JJ
     have not been implemented.
 
 tests:
@@ -94,22 +94,17 @@ tests:
   - source: "천리마"
     expected: "Chŏllima"
   # - source: "한나산"  # Typo in the original document
-  - source: "한라산"  
+  - source: "한라산"
     expected: "Hallasan"
   - source: "전라도"
     expected: "Jŏlla-do"
 
   # Note3.3
-  # The issue here is that in DPRK standard orthography, 
-  # 
-  # 
-  # See this page:
-  # https://en.wikipedia.org/wiki/North%E2%80%93South_differences_in_the_Korean_language#Sai_siot_(%EC%82%AC%EC%9D%B4_%EC%8B%9C%EC%98%B7,_%22middle_%E3%85%85%22)
 
-  # - source: "기대산"   # ROK: 깃대산 
+  # - source: "기대산"   # ROK: 깃대산
   #   expected: "Kittaesan"
   # - source: "새별읍"   # ROK: 샛별
-  #   expected: "Saeppyŏl-üp"  # hyphen 
+  #   expected: "Saeppyŏl-üp"  # hyphen
   # - source: "뒤문"    # ROK: 뒷문
   #   expected: "Twinmun"
 
@@ -147,7 +142,7 @@ map:
     # This system does not require transliteration of numerals
     # convert numbers to space + Hangul
     # - pattern: "([^0-9 ])(?=[0-9])"
-    #   result: "\\1 "      
+    #   result: "\\1 "
     # - pattern: "1"
     #   result: "일"
     # - pattern: "2"
@@ -292,7 +287,7 @@ map:
       result: "ᆯᄎ"
     - pattern: "ᆶ"
       result: "ᆯ"
-    
+
     # HANGUL JONGSEONG PIEUP-SIOS
     - pattern: "ᆹᄋ"
       result: "ᄇᄉ"
@@ -304,7 +299,7 @@ map:
       result: "ᆺᄊ"
     - pattern: "ᆻ"
       result: "ᆺ"
-    
+
     # HANGUL JONGSEONG CIEUC
     - pattern: "ᆽᄋ"
       result: "ᆺᄌ"

--- a/maps/kp-kor-Hang-Latn-2002.yaml
+++ b/maps/kp-kor-Hang-Latn-2002.yaml
@@ -12,9 +12,12 @@ description:
 
 notes:
 
+  - Here is a list of features that are listed in the guideline but 
+    not unimplemented in this map.
+
   - Note 3.2
     The combination n+r is romanized as -ll- only when it is "considered
-    to be longstanding". In this implementation, all n+r is romanized as
+    to be longstanding". In this implementation, all n+r will be romanized as
     -ll- for the sake of simplicity.
 
   - Note 3.3
@@ -27,15 +30,16 @@ notes:
     Except for the n-g combination, this has not been implemented.
 
   - Note 4.4
-    Geographical names may be transliterated or translated. In this map, all
-    names will be transliterated, not translated.
+    Geographical names "may be transliterated or translated". In this map, 
+    all names will be transliterated, not translated. Numerals will not be 
+    transliterated.
 
   - Note 4.5
-    Spacing rule for personal names have not been implemented.
+    Spacing rule for personal names has not been implemented.
 
   - Note 4.7
-    Optional omission of diacritics, and simplification of KK, TT, PP, SS, JJ
-    have not been implemented.
+    Optional omission of diacritics and optional simplification of 
+    KK, TT, PP, SS, JJ to single letter have not been implemented.
 
 tests:
   # Note1.5

--- a/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
+++ b/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
@@ -193,7 +193,7 @@ map:
       result: "ᆯᄎ"
     - pattern: "ᆶ"
       result: "ᆯ"
-    
+
     # HANGUL JONGSEONG PIEUP-SIOS
     - pattern: "ᆹᄋ"
       result: "ᄇᄉ"
@@ -205,7 +205,7 @@ map:
       result: "ᆺᄊ"
     - pattern: "ᆻ"
       result: "ᆺ"
-    
+
     # HANGUL JONGSEONG CIEUC
     - pattern: "ᆽᄋ"
       result: "ᆺᄌ"

--- a/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
+++ b/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
@@ -395,43 +395,43 @@ map:
     - pattern: "ᆼᄍ"
       result: "ngjj" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGCIEUC
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄀ"
-      result: "\\1g" # HANGUL JONGSEONG KIYEOK + CHOSEONG KIYEOK
+      result: "g" # VOWEL + CHOSEONG KIYEOK
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄂ"
-      result: "\\1n" # HANGUL JONGSEONG KIYEOK + CHOSEONG NIEUN
+      result: "n" # VOWEL + CHOSEONG NIEUN
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄃ"
-      result: "\\1d" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIKEUT
+      result: "d" # VOWEL + CHOSEONG TIKEUT
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄅ"
-      result: "\\1r" # HANGUL JONGSEONG KIYEOK + CHOSEONG RIEUL
+      result: "r" # VOWEL + CHOSEONG RIEUL
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄆ"
-      result: "\\1m" # HANGUL JONGSEONG KIYEOK + CHOSEONG MIEUM
+      result: "m" # VOWEL + CHOSEONG MIEUM
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄇ"
-      result: "\\1b" # HANGUL JONGSEONG KIYEOK + CHOSEONG PIEUP
+      result: "b" # VOWEL + CHOSEONG PIEUP
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄉ"
-      result: "\\1s" # HANGUL JONGSEONG KIYEOK + CHOSEONG SIOS
+      result: "s" # VOWEL + CHOSEONG SIOS
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄋ"
-      result: "\\1" # HANGUL JONGSEONG KIYEOK + CHOSEONG IEUNG
+      result: "" # VOWEL + CHOSEONG IEUNG
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄌ"
-      result: "\\1j" # HANGUL JONGSEONG KIYEOK + CHOSEONG CIEUC
+      result: "j" # VOWEL + CHOSEONG CIEUC
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄎ"
-      result: "\\1ch" # HANGUL JONGSEONG KIYEOK + CHOSEONG CHIEUCH
+      result: "ch" # VOWEL + CHOSEONG CHIEUCH
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄏ"
-      result: "\\1k" # HANGUL JONGSEONG KIYEOK + CHOSEONG KHIEUKH
+      result: "k" # VOWEL + CHOSEONG KHIEUKH
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄐ"
-      result: "\\1t" # HANGUL JONGSEONG KIYEOK + CHOSEONG THIEUTH
+      result: "t" # VOWEL + CHOSEONG THIEUTH
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄑ"
-      result: "\\1p" # HANGUL JONGSEONG KIYEOK + CHOSEONG PHIEUPH
+      result: "p" # VOWEL + CHOSEONG PHIEUPH
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄒ"
-      result: "h" # HANGUL JONGSEONG KIYEOK + CHOSEONG HIEUH
+      result: "h" # VOWEL + CHOSEONG HIEUH
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄁ"
-      result: "kk" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGKIYEOK
+      result: "kk" # VOWEL + CHOSEONG SSANGKIYEOK
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄄ"
-      result: "tt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIKEUT
+      result: "tt" # VOWEL + CHOSEONG SSANGTIKEUT
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄈ"
-      result: "pp" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGPIEUP
+      result: "pp" # VOWEL + CHOSEONG SSANGPIEUP
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄊ"
-      result: "ss" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGSIOS
+      result: "ss" # VOWEL + CHOSEONG SSANGSIOS
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄍ"
-      result: "jj" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGCIEUC
+      result: "jj" # VOWEL + CHOSEONG SSANGCIEUC
     - pattern: "ᆰᄀ"
       result: "lg" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG KIYEOK
     - pattern: "ᆰᄂ"

--- a/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
+++ b/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
@@ -128,14 +128,138 @@ map:
     - pattern: "$"
       result: " "
 
+    # HANGUL JONGSEONG SSANGKIYEOK
+    - pattern: "ᆩᄋ"
+      result: "ᆨᄁ"
+    - pattern: "ᆩ"
+      result: "ᆨ"
+
+    # HANGUL JONGSEONG SSANGKIYEOK
+    - pattern: "ᆪᄋ"
+      result: "ᆨᄉ"
+    - pattern: "ᆪ"
+      result: "ᆨ"
+
+    # HANGUL JONGSEONG NIEUN-CIEUC
+    - pattern: "ᆬᄋ"
+      result: "ᆫᄌ"
+    - pattern: "ᆬ"
+      result: "ᆫ"
+
+    # HANGUL JONGSEONG NIEUN-CIEUC
+    - pattern: "ᆭᄀ"
+      result: "ᆫᄏ"
+    - pattern: "ᆭᄃ"
+      result: "ᆫᄐ"
+    - pattern: "ᆭᄇ"
+      result: "ᆫᄑ"
+    - pattern: "ᆭᄌ"
+      result: "ᆫᄎ"
+    - pattern: "ᆭ"
+      result: "ᆫ"
+
+    # HANGUL JONGSEONG TIEUT
+    - pattern: "ᆮ(?=[ᄀᄁᄂᄃᄄᄅᄆᄇᄈᄉᄊᄌᄍᄎᄏᄐᄑᄒ])"
+      result: "ᆺ"
+
+    # HANGUL JONGSEONG RIEUL-SIOS
+    - pattern: "ᆳᄋ"
+      result: "ᆯᄉ"
+    - pattern: "ᆳ"
+      result: "ᆯ"
+
+    # HANGUL JONGSEONG RIEUL-THIEUTH
+    - pattern: "ᆴᄋ"
+      result: "ᆯᄐ"
+    - pattern: "ᆴ"
+      result: "ᆯ"
+
+    # HANGUL JONGSEONG RIEUL-PHIEUPH
+    - pattern: "ᆵᄋ"
+      result: "ᆯᄑ"
+    - pattern: "ᆵ(?=[ᄃᄄᄐ])"
+      result: "ᆯ"
+    - pattern: "ᆵ"
+      result: "ᄇ"
+
+    # HANGUL JONGSEONG RIEUL-HIEUH
+    - pattern: "ᆶᄀ"
+      result: "ᆯᄏ"
+    - pattern: "ᆶᄃ"
+      result: "ᆯᄐ"
+    - pattern: "ᆶᄇ"
+      result: "ᆯᄑ"
+    - pattern: "ᆶᄌ"
+      result: "ᆯᄎ"
+    - pattern: "ᆶ"
+      result: "ᆯ"
+    
+    # HANGUL JONGSEONG PIEUP-SIOS
+    - pattern: "ᆹᄋ"
+      result: "ᄇᄉ"
+    - pattern: "ᆹ"
+      result: "ᄇ"
+
+    # HANGUL JONGSEONG SSANG-SIOS
+    - pattern: "ᆻᄋ"
+      result: "ᆺᄊ"
+    - pattern: "ᆻ"
+      result: "ᆺ"
+    
+    # HANGUL JONGSEONG CIEUC
+    - pattern: "ᆽᄋ"
+      result: "ᆺᄌ"
+    - pattern: "ᆽ"
+      result: "ᆺ"
+
+    # HANGUL JONGSEONG CHIEUCH
+    - pattern: "ᆾᄋ"
+      result: "ᆺᄎ"
+    - pattern: "ᆾ"
+      result: "ᆺ"
+
+    # HANGUL JONGSEONG KHIEUKH
+    - pattern: "ᆿᄋ"
+      result: "ᆨᄏ"
+    - pattern: "ᆿ"
+      result: "ᆨ"
+
+    # HANGUL JONGSEONG THIEUTH
+    - pattern: "ᇀᄋ"
+      result: "ᆺᄐ"
+    - pattern: "ᇀ"
+      result: "ᆺ"
+
+    # HANGUL JONGSEONG PHIEUPH
+    - pattern: "ᇁᄋ"
+      result: "ᆸᄑ"
+    - pattern: "ᇁ"
+      result: "ᆸ"
+
+    # HANGUL JONGSEONG HIEUH
+    - pattern: "ᇂᄀ"
+      result: "ᄏ"
+    - pattern: "ᇂᄃ"
+      result: "ᄐ"
+    - pattern: "ᇂᄇ"
+      result: "ᄑ"
+    - pattern: "ᇂᄌ"
+      result: "ᄎ"
+    - pattern: "ᇂ"
+      result: ""
+
     # From Unicode Chart
     # https://github.com/unicode-org/cldr/blob/master/common/transforms/Korean-Latin-BGN.xml
+
+    - pattern: "ᆮᄋ" # HANGUL JONGSEONG TIEUT + CHOSEONG IEUNG
+      result: "d"
+
     - pattern: "ᆨᄀ"
       result: "kg" # HANGUL JONGSEONG KIYEOK + CHOSEONG KIYEOK
     - pattern: "ᆨᄂ"
       result: "ngn" # HANGUL JONGSEONG KIYEOK + CHOSEONG NIEUN
     - pattern: "ᆨᄃ"
-      result: "kd" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIKEUT
+      result: "kd" # HANGUL JONGSEONG KIYEOK + CHOSEONG TIEUT
     - pattern: "ᆨᄅ"
       result: "ngn" # HANGUL JONGSEONG KIYEOK + CHOSEONG RIEUL
     - pattern: "ᆨᄆ"
@@ -161,7 +285,7 @@ map:
     - pattern: "ᆨᄁ"
       result: "kkk" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGKIYEOK
     - pattern: "ᆨᄄ"
-      result: "ktt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIKEUT
+      result: "ktt" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGTIEUT
     - pattern: "ᆨᄈ"
       result: "kpp" # HANGUL JONGSEONG KIYEOK + CHOSEONG SSANGPIEUP
     - pattern: "ᆨᄊ"
@@ -173,7 +297,7 @@ map:
     - pattern: "ᆫᄂ"
       result: "nn" # HANGUL JONGSEONG NIEUN + CHOSEONG NIEUN
     - pattern: "ᆫᄃ"
-      result: "nd" # HANGUL JONGSEONG NIEUN + CHOSEONG TIKEUT
+      result: "nd" # HANGUL JONGSEONG NIEUN + CHOSEONG TIEUT
     - pattern: "ᆫᄅ"
       result: "ll" # HANGUL JONGSEONG NIEUN + CHOSEONG RIEUL
     - pattern: "ᆫᄆ"
@@ -199,7 +323,7 @@ map:
     - pattern: "ᆫᄁ"
       result: "nkk" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGKIYEOK
     - pattern: "ᆫᄄ"
-      result: "ntt" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGTIKEUT
+      result: "ntt" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGTIEUT
     - pattern: "ᆫᄈ"
       result: "npp" # HANGUL JONGSEONG NIEUN + CHOSEONG SSANGPIEUP
     - pattern: "ᆫᄊ"
@@ -211,7 +335,7 @@ map:
     - pattern: "ᆯᄂ"
       result: "ll" # HANGUL JONGSEONG RIEUL + CHOSEONG NIEUN
     - pattern: "ᆯᄃ"
-      result: "ld" # HANGUL JONGSEONG RIEUL + CHOSEONG TIKEUT
+      result: "ld" # HANGUL JONGSEONG RIEUL + CHOSEONG TIEUT
     - pattern: "ᆯᄅ"
       result: "ll" # HANGUL JONGSEONG RIEUL + CHOSEONG RIEUL
     - pattern: "ᆯᄆ"
@@ -237,7 +361,7 @@ map:
     - pattern: "ᆯᄁ"
       result: "lkk" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGKIYEOK
     - pattern: "ᆯᄄ"
-      result: "ltt" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGTIKEUT
+      result: "ltt" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGTIEUT
     - pattern: "ᆯᄈ"
       result: "lpp" # HANGUL JONGSEONG RIEUL + CHOSEONG SSANGPIEUP
     - pattern: "ᆯᄊ"
@@ -249,7 +373,7 @@ map:
     - pattern: "ᆷᄂ"
       result: "mn" # HANGUL JONGSEONG MIEUM + CHOSEONG NIEUN
     - pattern: "ᆷᄃ"
-      result: "md" # HANGUL JONGSEONG MIEUM + CHOSEONG TIKEUT
+      result: "md" # HANGUL JONGSEONG MIEUM + CHOSEONG TIEUT
     - pattern: "ᆷᄅ"
       result: "mn" # HANGUL JONGSEONG MIEUM + CHOSEONG RIEUL
     - pattern: "ᆷᄆ"
@@ -275,7 +399,7 @@ map:
     - pattern: "ᆷᄁ"
       result: "mkk" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGKIYEOK
     - pattern: "ᆷᄄ"
-      result: "mtt" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGTIKEUT
+      result: "mtt" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGTIEUT
     - pattern: "ᆷᄈ"
       result: "mpp" # HANGUL JONGSEONG MIEUM + CHOSEONG SSANGPIEUP
     - pattern: "ᆷᄊ"
@@ -287,7 +411,7 @@ map:
     - pattern: "ᆸᄂ"
       result: "mn" # HANGUL JONGSEONG PIEUP + CHOSEONG NIEUN
     - pattern: "ᆸᄃ"
-      result: "pd" # HANGUL JONGSEONG PIEUP + CHOSEONG TIKEUT
+      result: "pd" # HANGUL JONGSEONG PIEUP + CHOSEONG TIEUT
     - pattern: "ᆸᄅ"
       result: "mn" # HANGUL JONGSEONG PIEUP + CHOSEONG RIEUL
     - pattern: "ᆸᄆ"
@@ -313,7 +437,7 @@ map:
     - pattern: "ᆸᄁ"
       result: "pkk" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGKIYEOK
     - pattern: "ᆸᄄ"
-      result: "ptt" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGTIKEUT
+      result: "ptt" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGTIEUT
     - pattern: "ᆸᄈ"
       result: "ppp" # HANGUL JONGSEONG PIEUP + CHOSEONG SSANGPIEUP
     - pattern: "ᆸᄊ"
@@ -325,7 +449,7 @@ map:
     - pattern: "ᆺᄂ"
       result: "nn" # HANGUL JONGSEONG SIOS + CHOSEONG NIEUN
     - pattern: "ᆺᄃ"
-      result: "td" # HANGUL JONGSEONG SIOS + CHOSEONG TIKEUT
+      result: "td" # HANGUL JONGSEONG SIOS + CHOSEONG TIEUT
     - pattern: "ᆺᄅ"
       result: "nn" # HANGUL JONGSEONG SIOS + CHOSEONG RIEUL
     - pattern: "ᆺᄆ"
@@ -335,7 +459,7 @@ map:
     - pattern: "ᆺᄉ"
       result: "ts" # HANGUL JONGSEONG SIOS + CHOSEONG SIOS
     - pattern: "ᆺᄋ"
-      result: "d" # HANGUL JONGSEONG SIOS + CHOSEONG IEUNG
+      result: "s" # HANGUL JONGSEONG SIOS + CHOSEONG IEUNG
     - pattern: "ᆺᄌ"
       result: "tj" # HANGUL JONGSEONG SIOS + CHOSEONG CIEUC
     - pattern: "ᆺᄎ"
@@ -351,7 +475,7 @@ map:
     - pattern: "ᆺᄁ"
       result: "tkk" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGKIYEOK
     - pattern: "ᆺᄄ"
-      result: "ttt" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGTIKEUT
+      result: "ttt" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGTIEUT
     - pattern: "ᆺᄈ"
       result: "tpp" # HANGUL JONGSEONG SIOS + CHOSEONG SSANGPIEUP
     - pattern: "ᆺᄊ"
@@ -363,7 +487,7 @@ map:
     - pattern: "ᆼᄂ"
       result: "ngn" # HANGUL JONGSEONG IEUNG + CHOSEONG NIEUN
     - pattern: "ᆼᄃ"
-      result: "ngd" # HANGUL JONGSEONG IEUNG + CHOSEONG TIKEUT
+      result: "ngd" # HANGUL JONGSEONG IEUNG + CHOSEONG TIEUT
     - pattern: "ᆼᄅ"
       result: "ngn" # HANGUL JONGSEONG IEUNG + CHOSEONG RIEUL
     - pattern: "ᆼᄆ"
@@ -389,7 +513,7 @@ map:
     - pattern: "ᆼᄁ"
       result: "ngkk" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGKIYEOK
     - pattern: "ᆼᄄ"
-      result: "ngtt" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGTIKEUT
+      result: "ngtt" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGTIEUT
     - pattern: "ᆼᄈ"
       result: "ngpp" # HANGUL JONGSEONG IEUNG + CHOSEONG SSANGPIEUP
     - pattern: "ᆼᄊ"
@@ -401,7 +525,7 @@ map:
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄂ"
       result: "n" # VOWEL + CHOSEONG NIEUN
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄃ"
-      result: "d" # VOWEL + CHOSEONG TIKEUT
+      result: "d" # VOWEL + CHOSEONG TIEUT
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄅ"
       result: "r" # VOWEL + CHOSEONG RIEUL
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄆ"
@@ -427,7 +551,7 @@ map:
     - pattern: "(?<=[-A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄁ"
       result: "kk" # VOWEL + CHOSEONG SSANGKIYEOK
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄄ"
-      result: "tt" # VOWEL + CHOSEONG SSANGTIKEUT
+      result: "tt" # VOWEL + CHOSEONG SSANGTIEUT
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄈ"
       result: "pp" # VOWEL + CHOSEONG SSANGPIEUP
     - pattern: "(?<=[A-Za-z0-9ᅡᅢᅣᅤᅥᅦᅧᅨᅩᅪᅫᅬᅭᅮᅯᅰᅱᅲᅳᅴᅵ])ᄊ"
@@ -439,7 +563,7 @@ map:
     - pattern: "ᆰᄂ"
       result: "ngn" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG NIEUN
     - pattern: "ᆰᄃ"
-      result: "kd" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG TIKEUT
+      result: "kd" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG TIEUT
     - pattern: "ᆰᄅ"
       result: "ngn" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG RIEUL
     - pattern: "ᆰᄆ"
@@ -465,7 +589,7 @@ map:
     - pattern: "ᆰᄁ"
       result: "lkk" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGKIYEOK
     - pattern: "ᆰᄄ"
-      result: "ktt" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGTIKEUT
+      result: "ktt" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGTIEUT
     - pattern: "ᆰᄈ"
       result: "kpp" # HANGUL JONGSEONG RIEUL-KIYEOK + CHOSEONG SSANGPIEUP
     - pattern: "ᆰᄊ"
@@ -477,7 +601,7 @@ map:
     - pattern: "ᆱᄂ"
       result: "mn" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG NIEUN
     - pattern: "ᆱᄃ"
-      result: "md" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG TIKEUT
+      result: "md" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG TIEUT
     - pattern: "ᆱᄅ"
       result: "mn" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG RIEUL
     - pattern: "ᆱᄆ"
@@ -503,7 +627,7 @@ map:
     - pattern: "ᆱᄁ"
       result: "mkk" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGKIYEOK
     - pattern: "ᆱᄄ"
-      result: "mtt" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGTIKEUT
+      result: "mtt" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGTIEUT
     - pattern: "ᆱᄈ"
       result: "mpp" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG SSANGPIEUP
     - pattern: "ᆱᄊ"
@@ -515,7 +639,7 @@ map:
     - pattern: "ᆲᄂ"
       result: "mn" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG NIEUN
     - pattern: "ᆲᄃ"
-      result: "pd" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG TIKEUT
+      result: "pd" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG TIEUT
     - pattern: "ᆲᄅ"
       result: "mn" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG RIEUL
     - pattern: "ᆲᄆ"
@@ -541,7 +665,7 @@ map:
     - pattern: "ᆲᄁ"
       result: "pkk" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGKIYEOK
     - pattern: "ᆲᄄ"
-      result: "ptt" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGTIKEUT
+      result: "ptt" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGTIEUT
     - pattern: "ᆲᄈ"
       result: "lpp" # HANGUL JONGSEONG RIEUL-PIEUP + CHOSEONG SSANGPIEUP
     - pattern: "ᆲᄊ"
@@ -553,7 +677,7 @@ map:
     - pattern: "(?<= )ᄂ"
       result: "n" # HANGUL CHOSEONG NIEUN
     - pattern: "(?<= )ᄃ"
-      result: "d" # HANGUL CHOSEONG TIKEUT
+      result: "d" # HANGUL CHOSEONG TIEUT
     - pattern: "(?<= )ᄅ(?=[ᅣᅤᅧᅨᅭᅲ])"
       result: "" # HANGUL CHOSEONG RIEUL # R-onset rule
     - pattern: "(?<= )ᄅ"
@@ -583,9 +707,9 @@ map:
     - pattern: "(?<= )ᄭ"
       result: "kk" # HANGUL CHOSEONG SIOS-KIYEOK
     - pattern: "(?<= )ᄄ"
-      result: "tt" # HANGUL CHOSEONG SSANGTIKEUT
+      result: "tt" # HANGUL CHOSEONG SSANGTIEUT
     - pattern: "(?<= )ᄯ"
-      result: "tt" # HANGUL CHOSEONG SIOS-TIKEUT
+      result: "tt" # HANGUL CHOSEONG SIOS-TIEUT
     - pattern: "(?<= )ᄈ"
       result: "pp" # HANGUL CHOSEONG SSANGPIEUP
     - pattern: "(?<= )ᄲ"
@@ -643,7 +767,7 @@ map:
     - pattern: "ᆫ(?=[ -])"
       result: "n" # HANGUL JONGSEONG NIEUN
     - pattern: "ᆮ(?=[ -])"
-      result: "t" # HANGUL JONGSEONG TIKEUT
+      result: "t" # HANGUL JONGSEONG TIEUT
     - pattern: "ᆯ(?=[ -])"
       result: "l" # HANGUL JONGSEONG RIEUL
     - pattern: "ᆷ(?=[ -])"

--- a/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
+++ b/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
@@ -84,6 +84,8 @@ tests:
     expected: "Pyeongni Il-dong"
   - source: 평리2동
     expected: "Pyeongni I-dong"
+  - source: 탑안이
+    expected: "Tabani"
 
 map:
   character_separator: ""
@@ -295,7 +297,7 @@ map:
     - pattern: "ᆸᄉ"
       result: "ps" # HANGUL JONGSEONG PIEUP + CHOSEONG SIOS
     - pattern: "ᆸᄋ"
-      result: "p" # HANGUL JONGSEONG PIEUP + CHOSEONG IEUNG
+      result: "b" # HANGUL JONGSEONG PIEUP + CHOSEONG IEUNG
     - pattern: "ᆸᄌ"
       result: "pj" # HANGUL JONGSEONG PIEUP + CHOSEONG CIEUC
     - pattern: "ᆸᄎ"
@@ -333,7 +335,7 @@ map:
     - pattern: "ᆺᄉ"
       result: "ts" # HANGUL JONGSEONG SIOS + CHOSEONG SIOS
     - pattern: "ᆺᄋ"
-      result: "t" # HANGUL JONGSEONG SIOS + CHOSEONG IEUNG
+      result: "d" # HANGUL JONGSEONG SIOS + CHOSEONG IEUNG
     - pattern: "ᆺᄌ"
       result: "tj" # HANGUL JONGSEONG SIOS + CHOSEONG CIEUC
     - pattern: "ᆺᄎ"
@@ -477,7 +479,7 @@ map:
     - pattern: "ᆱᄃ"
       result: "md" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG TIKEUT
     - pattern: "ᆱᄅ"
-      result: "ml" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG RIEUL
+      result: "mn" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG RIEUL
     - pattern: "ᆱᄆ"
       result: "lm" # HANGUL JONGSEONG RIEUL-MIEUM + CHOSEONG MIEUM
     - pattern: "ᆱᄇ"

--- a/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
+++ b/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
@@ -151,7 +151,7 @@ map:
     - pattern: "ᆨᄏ"
       result: "kk" # HANGUL JONGSEONG KIYEOK + CHOSEONG KHIEUKH # NOTE: the dash is always skipped
     - pattern: "ᆨᄐ"
-      result: "kt’" # HANGUL JONGSEONG KIYEOK + CHOSEONG THIEUTH
+      result: "kt" # HANGUL JONGSEONG KIYEOK + CHOSEONG THIEUTH
     - pattern: "ᆨᄑ"
       result: "kp" # HANGUL JONGSEONG KIYEOK + CHOSEONG PHIEUPH
     - pattern: "ᆨᄒ"
@@ -187,7 +187,7 @@ map:
     - pattern: "ᆫᄎ"
       result: "nch" # HANGUL JONGSEONG NIEUN + CHOSEONG CHIEUCH
     - pattern: "ᆫᄏ"
-      result: "nk’" # HANGUL JONGSEONG NIEUN + CHOSEONG KHIEUKH
+      result: "nk" # HANGUL JONGSEONG NIEUN + CHOSEONG KHIEUKH
     - pattern: "ᆫᄐ"
       result: "nt" # HANGUL JONGSEONG NIEUN + CHOSEONG THIEUTH
     - pattern: "ᆫᄑ"
@@ -343,7 +343,7 @@ map:
     - pattern: "ᆺᄐ"
       result: "tt" # HANGUL JONGSEONG SIOS + CHOSEONG THIEUTH
     - pattern: "ᆺᄑ"
-      result: "tp’" # HANGUL JONGSEONG SIOS + CHOSEONG PHIEUPH
+      result: "tp" # HANGUL JONGSEONG SIOS + CHOSEONG PHIEUPH
     - pattern: "ᆺᄒ"
       result: "th" # HANGUL JONGSEONG SIOS + CHOSEONG HIEUH
     - pattern: "ᆺᄁ"


### PR DESCRIPTION
- Fix previously unhandled tail-jamos for "-viajamo" maps.
(which are also unhandled in this chart: https://github.com/unicode-org/cldr/blob/master/common/transforms/Korean-Latin-BGN.xml)

- Add `kp-kor-Hang-Latn-2002`  (#121)

- Fix Typos