### PR TITLE
Remove duplicate code from mappings

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/interscript.gemspec
+++ b/interscript.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.bindir = 'bin'
+  spec.bindir = "bin"
 
   spec.add_dependency "thor"
 
-  spec.add_development_dependency "pry"
   spec.add_development_dependency "debase"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "ruby-debug-ide"

--- a/lib/interscript/mapping.rb
+++ b/lib/interscript/mapping.rb
@@ -64,7 +64,6 @@ module Interscript
       @url = mappings.fetch("url", nil)
       @name = mappings.fetch("name", nil)
       @notes = mappings.fetch("notes", nil)
-      @notes = mappings.fetch("notes", nil)
       @tests = mappings.fetch("tests", [])
       @language = mappings.fetch("language", nil)
       @description = mappings.fetch("description", nil)


### PR DESCRIPTION
There was a duplicate code in the mappgins.rb, this commit removes that duplicate lines of code. This commit also adds a setup script so we can easily run that one to install our project dependencies

Fixes: #208