### PR TITLE
Rename `extend` feature to `inherit`

### DIFF
--- a/lib/interscript/mapping.rb
+++ b/lib/interscript/mapping.rb
@@ -78,15 +78,18 @@ module Interscript
       @postrules = mappings["map"]["postrules"] || []
       @characters = mappings["map"]["characters"] || {}
 
-      include_extended_characters_mappings(mappings)
+      include_inherited_mappings(mappings)
     end
 
-    def include_extended_characters_mappings(mappings)
-      extend_systems = mappings["map"]["extend"]
+    def include_inherited_mappings(mappings)
+      inherit_systems = mappings["map"]["inherit"]
 
-      if extend_systems
-        extended_mapping = Mapping.for(extend_systems, depth: depth + 1)
-        @characters = (extended_mapping.characters || {}).merge(characters)
+      if inherit_systems
+        inherited_mapping = Mapping.for(inherit_systems, depth: depth + 1)
+
+        @rules = [inherited_mapping.rules, rules].flatten
+        @postrules = [inherited_mapping.postrules, postrules].flatten
+        @characters = inherited_mapping.characters.merge(characters)
       end
     end
   end

--- a/maps/alalc-ben-Beng-Latn-2017.yaml
+++ b/maps/alalc-ben-Beng-Latn-2017.yaml
@@ -43,7 +43,7 @@ tests:
     expected: "tya"
 
 map:
-  extend: "un-ben-Beng-Latn-2016"
+  inherit: "un-ben-Beng-Latn-2016"
 
   characters:
 

--- a/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
+++ b/maps/bgn-kor-Hang-Latn-1939-viajamo.yaml
@@ -83,7 +83,7 @@ map:
   character_separator: ""
   word_separator: " "
   title_case: True
-  extend: "nil-kor-Hang-Hang-jamo"
+  inherit: "nil-kor-Hang-Hang-jamo"
 
   rules:
     # convert numbers to space + Hangul

--- a/maps/kp-kor-Hang-Latn-2002.yaml
+++ b/maps/kp-kor-Hang-Latn-2002.yaml
@@ -139,7 +139,7 @@ map:
   character_separator: ""
   word_separator: " "
   title_case: True
-  extend: "nil-kor-Hang-Hang-jamo"
+  inherit: "nil-kor-Hang-Hang-jamo"
 
   rules:
 

--- a/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
+++ b/maps/moct-kor-Hang-Latn-2000-viajamo.yaml
@@ -91,7 +91,7 @@ map:
   character_separator: ""
   word_separator: " "
   title_case: True
-  extend: "nil-kor-Hang-Hang-jamo"
+  inherit: "nil-kor-Hang-Hang-jamo"
 
   rules:
     # convert numbers to space + Hangul

--- a/spec/interscript/mapping_spec.rb
+++ b/spec/interscript/mapping_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Interscript::Mapping do
       end
     end
 
-    context "with valid and extened system" do
-      it "returns system mappings with extended rules" do
+    context "with valid and inherited system" do
+      it "returns system mappings with inherited rules" do
         system_code = "alalc-ben-Beng-Latn-2017"
 
         mapping = Interscript::Mapping.for(system_code)


### PR DESCRIPTION
This commit rename the options to inherit an existing mappings from `extend` to `inherit`. This commit also includes the rules and post rules with the inheritance tree.

So, now if any mapping is inheriting another mappings, then it will include the `rules` and `postrules` along with characters

Related #120