### PR TITLE
Implement chain

### DIFF
--- a/lib/g2pwrapper.py
+++ b/lib/g2pwrapper.py
@@ -1,13 +1,27 @@
 import g2p, SequiturTool
 import numpy
 
-def transliterate(word):
+def transliterate(model, word):
 
   class Struct:
       def __init__(self, **entries):
           self.__dict__.update(entries)
 
-  options = Struct(**{'profile': None, 'resource_usage': None, 'psyco': None, 'tempdir': None, 'trainSample': None, 'develSample': None, 'testSample': None, 'checkpoint': None, 'resume_from_checkpoint': None, 'shouldTranspose': None, 'modelFile': './lib/model-7', 'newModelFile': None, 'shouldTestContinuously': None, 'shouldSelfTest': None, 'lengthConstraints': None, 'shouldSuppressNewMultigrams': None, 'viterbi': None, 'shouldRampUp': None, 'shouldWipeModel': None, 'shouldInitializeWithCounts': None, 'minIterations': 20, 'maxIterations': 100, 'eager_discount_adjustment': None, 'fixed_discount': None, 'encoding': 'UTF-8', 'phoneme_to_phoneme': None, 'test_segmental': None, 'testResult': None, 'applySample': None, 'applyWord': word, 'variants_mass': None, 'variants_number': None, 'fakeTranslator': None, 'stack_limit': None})
+  model_path = {
+    'pythainlp_lexicon': './lib/model-7', 
+    'wiktionary_phonemic': './lib/tha-pt-b-7'
+  }
+
+  connector_dict = {
+    'pythainlp_lexicon': '', 
+    'wiktionary_phonemic': '-'
+  }
+
+
+  modelFile = model_path[model]
+  connector = connector_dict[model]
+
+  options = Struct(**{'profile': None, 'resource_usage': None, 'psyco': None, 'tempdir': None, 'trainSample': None, 'develSample': None, 'testSample': None, 'checkpoint': None, 'resume_from_checkpoint': None, 'shouldTranspose': None, 'modelFile': modelFile , 'newModelFile': None, 'shouldTestContinuously': None, 'shouldSelfTest': None, 'lengthConstraints': None, 'shouldSuppressNewMultigrams': None, 'viterbi': None, 'shouldRampUp': None, 'shouldWipeModel': None, 'shouldInitializeWithCounts': None, 'minIterations': 20, 'maxIterations': 100, 'eager_discount_adjustment': None, 'fixed_discount': None, 'encoding': 'UTF-8', 'phoneme_to_phoneme': None, 'test_segmental': None, 'testResult': None, 'applySample': None, 'applyWord': word, 'variants_mass': None, 'variants_number': None, 'fakeTranslator': None, 'stack_limit': None})
 
   loadSample = g2p.loadG2PSample
 
@@ -17,6 +31,4 @@ def transliterate(word):
   translator = g2p.Translator(model)
   del model
 
-  # Keep only Thai strings
-
-  return ''.join(translator(tuple(word)))
+  return connector.join(translator(tuple(word)))

--- a/lib/interscript/mapping.rb
+++ b/lib/interscript/mapping.rb
@@ -19,6 +19,7 @@ module Interscript
       :creation_date,
       :source_script,
       :destination_script,
+      :chain,
       :character_separator,
       :word_separator,
       :title_case,
@@ -80,6 +81,7 @@ module Interscript
       @creation_date = mappings.fetch("creation_date", nil)
       @source_script = mappings.fetch("source_script", nil)
       @destination_script = mappings.fetch("destination_script", nil)
+      @chain = mappings.fetch("chain", [])
       @character_separator = mappings["map"]["character_separator"] || nil
       @word_separator = mappings["map"]["word_separator"] || nil
       @title_case = mappings["map"]["title_case"] || false

--- a/maps/royin-tha-Thai-Latn-1939-generic.yaml
+++ b/maps/royin-tha-Thai-Latn-1939-generic.yaml
@@ -1,0 +1,90 @@
+---
+authority_id: royin
+id: 1939-generic
+language: tha
+source_script: Thai
+destination_script: Latn
+name: Royal Thai General System of Transcription (1939) Generic
+url: http://www.siamese-heritage.org/jsspdf/1941/JSS_033_1d_RoyalInstituteTranscriptionOfThaiIntoRomanCharacters.pdf
+creation_date: 1939
+adoption_date: 
+description: |
+  This map loads two external maps to convert Thai text first into phonemic Thai,
+  and then into IPA transcription.
+  
+  The IPA transcription will then be handled by this map, and converted into
+  Royal Thai General System of Transcription (1939)
+
+  The first two parts are done via two external maps.
+
+
+notes: |
+  This is a draft for the map.
+  The conversion from Thai to Phonemic Thai is still work-in-progress.
+
+tests:
+  - source: "กษัตริย์"
+    expected: "kasat"
+  - source: "ประกาศ"
+    expected: "prakat"
+  # - source: "ราชบุรี่"
+  #   expected: "ratburi"
+  # - source: "ปากลัด"
+  #   expected: "pak-lat"
+
+
+chain: ["var-tha-Thai-Thai-phonemic" ,"var-tha-Thai-Zsym-ipa"]
+
+map:
+  title-case: false
+  word_separator: " "  
+
+  rules:
+    - pattern: '[˩˨˧˦˥]'
+      result : ''
+
+  postrules:
+    - pattern: '\.'
+      result:  ''
+
+  characters:
+
+  dictionary:
+
+    '̯': ''
+    '̚': ''
+
+    'ʔ': ''
+    'ː': ''
+
+    't͡ɕʰ': 'ch'
+    't͡ɕ': 'čh'
+    'ŋ': 'ng'
+    'j': 'y'
+    'ɔ': 'o̦'
+    'ɤ': 'œ' 
+    'ɛ': 'æ'
+    'ɯ': 'ư'
+    'ʰ': 'h'
+
+    'aːw': 'ao'
+    'aw': 'ao'
+    'a̯w': 'ao'
+    'eːw': 'eo'
+    'ew': 'eo'
+    'ɛːw': 'aeo'
+    'ɛw': 'æo'
+    'iːw': 'iu'
+    'iw': 'iu'
+
+    'aːj': 'ai'
+    'aj': 'ai'
+    'a̯j': 'ai'
+    'ɔːj': 'o̦i'
+    'ɔj': 'o̦i'
+    'oːj': 'oi'
+    'oj': 'oi'
+    'ɤːj': 'œi'
+    'ɤj': 'œi'
+    'uːj': 'ui'
+    'uj': 'ui'

--- a/maps/royin-tha-Thai-Latn-1968.yaml
+++ b/maps/royin-tha-Thai-Latn-1968.yaml
@@ -1,19 +1,19 @@
 ---
 authority_id: royin
-id: 1999-chained
+id: 1968-chained
 language: tha
 source_script: Thai
 destination_script: Latn
-name: Royal Thai General System of Transcription (1999)
+name: Royal Thai General System of Transcription (1968)
 url: http://www.royin.go.th/wp-content/uploads/royin-ebook/276/FileUpload/758_6484.pdf
-creation_date: 1999
+creation_date: 1968
 adoption_date: 
 description: |
   This map loads two external maps to convert Thai text first into phonemic Thai,
   and then into IPA transcription.
   
   The IPA transcription will then be handled by this map, and converted into
-  Royal Thai General System of Transcription (1999)
+  Royal Thai General System of Transcription (1968).
 
   The first two parts are done via two external maps.
 
@@ -36,11 +36,11 @@ tests:
   - source: "บุรี"
     expected: "buri"
   - source: "สตึก"
-    expected: "satuek"
+    expected: "satuk"
   - source: "พืช"
-    expected: "phuet"
+    expected: "phut"
   - source: "บรบือ"
-    expected: "borabue"
+    expected: "borabu"
   - source: "ภู"
     expected: "phu"
   - source: "ปะนาเระ"
@@ -74,9 +74,9 @@ tests:
   - source: "เทียน"
     expected: "thian"
   # - source: "เกือะ"
-  #   expected: "kuea"
+  #   expected: "kua"
   - source: "เมือง"
-    expected: "mueang"
+    expected: "muang"
   # - source: "ผัวะ"
   #   expected: "phua"
   - source: "บัว"
@@ -104,7 +104,7 @@ tests:
   # - source: "ดอย"
   #   expected: "doi"
   # - source: "งิ้ว"
-  #   expected: "ngio"
+  #   expected: "ngiu"
   - source: "เร็ว"
     expected: "reo"
   # - source: "เลว"
@@ -112,14 +112,13 @@ tests:
   # - source: "เลย"
   #   expected: "loei"
   # - source: "เดือย"
-  #   expected: "dueai"
+  #   expected: "duai"
   # - source: "ห้วย"
   #   expected: "huai"
   - source: "แมว"
     expected: "maeo"
   - source: "เขียว"
-    expected: "khiao"
-
+    expected: "khieu"
 
 chain: ["var-tha-Thai-Thai-phonemic" ,"var-tha-Thai-Zsym-ipa"]
 
@@ -154,18 +153,18 @@ map:
     'ɔ': 'o'
     'ɤ': 'oe' 
     'ɛ': 'ae'
-    'ɯ': 'ue' # New spelling, was u in 1968
+    'ɯ': 'u'
     'ʰ': 'h'
 
     'aːw': 'ao'
     'aw': 'ao'
-    'a̯w': 'ao' # New spelling, was eu in 1968
+    'a̯w': 'eu'
     'eːw': 'eo'
     'ew': 'eo'
     'ɛːw': 'aeo'
     'ɛw': 'aeo'
-    'iːw': 'io' # New spelling, was iu in 1968
-    'iw': 'io' # New spelling, was iu in 1968
+    'iːw': 'iu'
+    'iw': 'iu'
 
     'aːj': 'ai'
     'aj': 'ai'

--- a/maps/royin-tha-Thai-Latn-1999-chained.yaml
+++ b/maps/royin-tha-Thai-Latn-1999-chained.yaml
@@ -1,0 +1,91 @@
+---
+authority_id: royin
+id: 1999-chained
+language: tha
+source_script: Thai
+destination_script: Latn
+name: Royal Thai General System of Transcription (1999)
+url: http://www.royin.go.th/wp-content/uploads/royin-ebook/276/FileUpload/758_6484.pdf
+creation_date: 1999
+adoption_date: 
+description: |
+  This map loads two external maps to convert Thai text first into phonemic Thai,
+  and then into IPA transcription.
+  
+  The IPA transcription will then be handled by this map, and converted into
+  Royal Thai General System of Transcription (1999)
+
+  The first two parts are done via two external maps.
+
+notes: |
+  The conversion from Thai to Phonemic Thai is still work-in-progress.
+
+tests:
+  - source: 'ภาษาไทย'
+    expected: 'phasathai'
+  - source: 'ไทย'
+    expected: 'thai'
+  - source: 'เชียงใหม่'
+    expected: 'chiangmai'
+  - source: 'ใหม่'
+    expected: 'mai'
+  - source: 'ใคร'
+    expected: 'khrai'
+  - source: "ที่"
+    expected: "thi"
+  - source: "เป็น"
+    expected: "pen"
+  - source: "ใน"
+    expected: "nai"
+  - source: "การ"
+    expected: "kan"
+  - source: "มี"
+    expected: "mi"
+  - source: "ได้"
+    expected: "dai"
+  - source: "ของ"
+    expected: "khong"
+  - source: "ไม่"
+    expected: "mai"
+  # - source: "สถานีปางต้นผึ้ง"
+  #   expected: "sathanipangtonphueng"
+  # - source: "ไพศาลี"
+  #   expected: "phaisali"
+  # - source: "โรงเรียนไม้เรียงประชาสรรค์"
+  #   expected: "rongrianmairiangprachasan"
+
+chain: ["var-tha-Thai-Thai-phonemic" ,"var-tha-Thai-Zsym-ipa"]
+
+map:
+  title-case: false
+  word_separator: " "  
+
+  rules:
+
+  postrules:
+    - pattern: '\.'
+      result:  ''
+
+  characters:
+    '[˩˨˧˦˥]': ''
+    'chh': 'ch'
+
+  dictionary:
+
+    '̯': ''
+    '̚': ''
+
+    'ʔ' : ''
+    'ː': ''
+
+    'ʰ': 'h'
+    'c': 'ch'
+    'ŋ': 'ng'
+    '.j': 'y'
+    'j': 'i'
+    'w': 'o'
+    'ɔ': 'o'
+    'ɤ': 'oe' 
+    'ɛ': 'ae'
+    'ɯ': 'ue'
+    't͡ɕ': 'c'

--- a/maps/var-tha-Thai-Thai-phonemic.yaml
+++ b/maps/var-tha-Thai-Thai-phonemic.yaml
@@ -9,7 +9,9 @@ url:
 creation_date: 
 adoption_date: 
 description:
-  This map performs two tasks. First the text is segmented using a dictionary.
+  This map performs two tasks. 
+
+  First the text is segmented using a dictionary.
   Then Thai texts will be sent to an external module to get converted into
   Phonemic Thai.
 
@@ -19,12 +21,34 @@ description:
 notes: |
 
 tests:
+  - source: "ที่เปิดขวด"
+    expected: "ที่-เปิด-ขวด"
+  - source: "พื้นหลัง"
+    expected: "พื้น-หฺลัง"
+  - source: "สมชาย"
+    expected: "สม-ชาย"
+  - source: "อ่อนข้อ"
+    expected: "อ็่อน-ค่อ"
+  - source: "โครยอ"
+    expected: "โค-ระ-ยอ"
+  - source: "ไล่ออก"
+    expected: "ไล่-ออก"
+  - source: "ไส้เลื่อน"
+    expected: "ไส้-เลื่อน"
+  - source: "ความวาว"
+    expected: "คฺวาม-วาว"
+  - source: "ไอกรน"
+    expected: "ไอ-กฺรน"
+  - source: "ไอซียู"
+    expected: "ไอ-ซี-ยู"
+  - source: "ไอซ์แลนด์"
+    expected: "ไอ๊ส-แลน"
 
 map:
   title-case: false
   word_separator: " "  
-  segmentation: ""
-  transcription: "sequitur.pythainlp_lexicon"
+  segmentation: "" # Not yet implemented
+  transcription: "sequitur.wiktionary_phonemic"
 
   rules:
 


### PR DESCRIPTION
This commit adds an optional array `chain` to maps, so that Thai to Latn maps, which require separate transliteration sub-maps for intermediate steps, can be implemented.

This line is added to the `royin-tha-Thai-Latn-1999-chained.yaml` map file:
```
chain: ["var-tha-Thai-Thai-phonemic" ,"var-tha-Thai-Zsym-ipa"]
```

Maps specified in the `chain` array will be applied sequentially during transliteration. The output of the first map (in this case, `var-tha-Thai-Thai-phonemic`) will be fed as the input of the second map (here, `var-tha-Thai-Zsym-ipa`). After all maps in the `chain` array are applied, the remaining transliteration steps in the current file will be performed.

Following lines have been added to the `transliterate` function to achieve this.
````
      # First, apply chained transliteration as specified in the list `chain`
      chain = mapping.chain.dup
      while chain.length > 0
        string = transliterate(chain.shift, string, maps)
      end
````