### PR TITLE
Implement ISO 15919 for Devanagari

### DIFF
--- a/maps/iso-asm-Beng-Latn-15919-2001.yaml
+++ b/maps/iso-asm-Beng-Latn-15919-2001.yaml
@@ -1,0 +1,75 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:asm
+source_script: Beng
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+tests:
+  - source: "অসমীয়া কবিতা"
+    expected: "asamaīẏaā kabaitaā"
+  - source: "কবিৰ আজি জন্মদিন"
+    expected: "kabaiva ājai janamadaina"
+  - source: "বেৰুটত এমাহৰ পাছতে পুনৰ ভয়ংকৰ অগ্নিকাণ্ড"
+    expected: "baevauṭata emaāhava paāchatae paunava bhaya়ṁkava aganaikaāṇaḍa"
+  - source: "ভঙাৰ বিৰুদ্ধে আৱেদন দাখিল কংগনাৰ"
+    expected: "bhaṅaāva baivaudadhae āraedana daākhaila kaṁganaāva"
+  - source: "আপুনি পঢ়ি ভাল পাব পৰা বাতৰি"
+    expected: "āpaunai paṙhai bhaāla paāba pavaā baātavai"
+  - source: "শ্ৰীৰামপুৰত গৰুভৰ্তি ট্ৰাক জব্দ, দুজনক আটক"
+    expected: "śavaīvaāmapauvata gavaubhavatai ṭavaāka jabada, daujanaka āṭaka"
+  - source: "কেনে আছে প্ৰাক্তন"
+    expected: "kaenae āchae pavaākatana"
+  - source: "কমুম্বাইৰ মেয়ৰৰ দেহত কোভিড পজিটিভ"
+    expected: "kamaumabaāiva maeẏavava daehata kaobhaiḍa pajaiṭaibha"
+  - source: "টুইটাৰযোগে খোদ সদৰী কৰে এই কথা"
+    expected: "ṭauiṭaāvayaogae khaoda sadavaī kavae ei kathaā"
+  - source: "লখিমপুৰ জিলাৰ নাৰায়ণপুৰৰ বৰপথাৰত আজি প্ৰশান্তি ধাম নামেৰে এখন বৃদ্ধাশ্ৰমৰ শুভাৰম্ভ কৰা হয়"
+    expected: "lakhaimapauva jailaāva naāvaāẏaṇapauvava bavapathaāvata ājai pavaśaānatai dhaāma naāmaevae ekhana baṛdadhaāśavamava śaubhaāvamabha kavaā haẏa"
+
+map:
+  inherit: 'iso-ben-Beng-Latn-15919-2001'
+
+  characters:
+    'ৰ': 'va'
+    'ৱ': 'ra'

--- a/maps/iso-ben-Beng-Latn-15919-2001.yaml
+++ b/maps/iso-ben-Beng-Latn-15919-2001.yaml
@@ -1,0 +1,175 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:ben
+source_script: Beng
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+     -  Vowel hiatus, not digraph transliteration of diphthongs; as in Bengali ba:i (not bai), “book”.
+     -  Unexpected use of secondary ya/ẏa , as in Bengali r:yāpāra , English “wrapper” (using full r); a:yā (not ayā ).
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "আগুয়েরোর হাঁটুর চোট"
+    expected: "āgauẏaeraora haām̐ṭaura caoṭa"
+  - source: "তঅস্ত্রোপচারের আশ্রয় নিতে হবে এ তারকাকে, তাই দলে জায়গা পাননি"
+    expected: "taasataraopacaāraera āśaraẏa naitae habae e taārakaākae, taāi dalae jaāẏagaā paānanai"
+  - source: "ওদিকে সদ্য করোনা থেকে ফিরে এসে দাপটের সঙ্গে পিএসজির হয়ে খেলে যাওয়া দি মারিয়া কেন ডাক পাননি, কেউ জানে না"
+    expected: "odaikae sadaya karaonaā thaekae phairae esae daāpaṭaera saṅagae paiesajaira haẏae khaelae yaāoẏaā dai maāraiẏaā kaena ḍaāka paānanai, kaeu jaānae naā"
+  - source: "তিন বিভাগে শনিবার থেকে ভারী বৃষ্টি, কমবে তাপমাত্রা"
+    expected: "taina baibhaāgae śanaibaāra thaekae bhaāraī baṛṣaṭai, kamabae taāpamaātaraā"
+  - source: "ফেসবুকে সময় নষ্ট না করে মায়ের সঙ্গে আড্ডা ভালোবাসেন তিনি"
+    expected: "phaesabaukae samaẏa naṣaṭa naā karae maāẏaera saṅagae āḍaḍaā bhaālaobaāsaena tainai"
+  - source: "এখনই আর্জেন্টিনার জার্সি খুলো না—দি মারিয়াকে কোচ"
+    expected: "ekhanai ārajaenaṭainaāra jaārasai khaulao naā—dai maāraiẏaākae kaoca"
+  - source: "প্রিয় তারকার আওয়াজ শুনে কোমা থেকে জেগে উঠলেন তিনি"
+    expected: "paraiẏa taārakaāra āoẏaāja śaunae kaomaā thaekae jaegae uṭhalaena tainai"
+  - source: "সুয়ারেজকে ‘বের করে দেওয়া’য় বার্সাকে ধুয়ে দিলেন মেসি"
+    expected: "sauẏaāraejakae ‘baera karae daeoẏaā’ẏa baārasaākae dhauẏae dailaena maesai"
+  - source: "আমি না থাকলে আর্জেন্টিনা দলে মেসিরও থাকার যোগ্যতা নেই"
+    expected: "āmai naā thaākalae ārajaenaṭainaā dalae maesairao thaākaāra yaogayataā naei"
+  - source: "তবে, নিয়মিত মুখগুলোর মধ্যে দলে নেই মেসির দুই ‘প্রিয় বন্ধু’ পিএসজির মিডফিল্ডার আনহেল দি মারিয়া ও ম্যানচেস্টার সিটির সার্জিও আগুয়েরো"
+    expected: "tabae, naiẏamaita maukhagaulaora madhayae dalae naei maesaira daui ‘paraiẏa banadhau’ paiesajaira maiḍaphailaḍaāra ānahaela dai maāraiẏaā o mayaānacaesaṭaāra saiṭaira saārajaio āgauẏaerao"
+
+map:
+  characters:
+
+    #vowel characters
+
+    'অ': 'a'
+    'আ': 'ā'
+    'ই': 'i'
+    'ঈ': 'ī'
+    'উ': 'u'
+    'ঊ': 'ū'
+    'ঋ': 'ṛ'
+    'ৠ': 'ṝ'
+    'ঌ': 'ḻ'
+    'ৡ': 'ḹ'
+    'এ': 'e'
+    'ঐ': 'ai'
+    'ও': 'o'
+    'ঔ': 'au'
+
+    'া': 'ā'
+    'ি': 'i'
+    'ী': 'ī'
+    'ু': 'u'
+    'ূ': 'ū'
+    'ৃ': 'ṛ'
+    'ৄ': 'ṝ'
+    'ৢ': 'ḻ'
+    'ৣ': 'ḹ'
+    'ে': 'e'
+    'ৈ': 'ai'
+    'ো': 'o'
+    'ৌ': 'au'
+
+
+    'ং':	'ṁ'
+    'ঁ':	'm̐'
+    'ঃ':	'ḥ'
+
+    # Consonant characters
+
+    'ক': 'ka'
+    'খ': 'kha'
+    'গ': 'ga'
+    'ঘ': 'gha'
+    'ঙ': 'ṅa'
+    'চ': 'ca'
+    'ছ': 'cha'
+    'জ': 'ja'
+    'ঝ': 'jha'
+    'ঞ': 'ña'
+    'ট': 'ṭa'
+    'ঠ': 'ṭha'
+    'ড': 'ḍa'
+    'ঢ': 'ḍha'
+    'ণ': 'ṇa'
+    'ত': 'ta'
+    'থ': 'tha'
+    'দ': 'da'
+    'ধ': 'dha'
+    'ন': 'na'
+    'প': 'pa'
+    'ফ': 'pha'
+    'ব': 'ba'
+    'ভ': 'bha'
+    'ম': 'ma'
+    'য': 'ya'
+    'র': 'ra'
+    'ল': 'la'
+    'শ': 'śa'
+    'ষ': 'ṣa'
+    'স': 'sa'
+    'হ': 'ha'
+
+    'ড়': 'ṙa'
+    'ঢ়': 'ṙha'
+    'য়': 'ẏa'
+
+
+    # for semivowel rule no. 5
+
+    'যঁ': 'm̐ya'
+    'রঁ': 'm̐ra'
+    'লঁ': 'm̐la'
+    'বঁ': 'm̐va'
+
+    'ৎ': 't'
+    '্': ''
+
+
+   # numbers
+
+    '১': '1' 
+    '২': '2'
+    '৩': '3'
+    '৪': '4'
+    '৫': '5'
+    '৬': '6'
+    '৭': '7'
+    '৮': '8'
+    '৯': '9'
+    '০': '0'
+

--- a/maps/iso-guj-Gujr-Latn-15919-2001.yaml
+++ b/maps/iso-guj-Gujr-Latn-15919-2001.yaml
@@ -1,0 +1,214 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:guj
+source_script: Gujr
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "અમિત શાહનો કોરોના રિપોર્ટ 2 ઓગસ્ટે પોઝિટિવ આવ્યો હતો, ત્યારથી તેમનું સ્વાસ્થ્ય સારું નથી"
+    expected: "amaita śaāhanao kaoraonaā raipaoratạ 2 ogasatạe paojhaitạiva āvayao hatao, tayaārathaī taemanauṁ savaāsathaya saārauṁ nathaī"
+  - source: "મેદાંતા હોસ્પિટલમાં તેમનો ઇલાજ ચાલી રહ્યો હતો"
+    expected: "maedaāṁtaā haosapaitạlamaāṁ taemanao ilaāja caālaī rahayao hatao"
+  - source: "ભારતના વિશ્વનાથન આનંદે શેનયાનમાં પહેલો ફિડે શતરંજ વિશ્વ કપ જીત્યો"
+    expected: "bhaāratanaā vaiśavanaāthana ānaṁdae śaenayaānamaāṁ pahaelao phaiḍae śataraṁja vaiśava kapa jaītayao"
+  - source: "ભારતીય વડા પ્રધાન જવાહરલાલ નેહરુએ 40 લાખ હિન્દુઓ અને મુસલમાનોના પારસ્પરિક સ્થાનાંતરણનું સૂચન આપ્યું"
+    expected: "bhaārataīya vaḍaā paradhaāna javaāharalaāla naeharaue 40 laākha hainadauo anae mausalamaānaonaā paārasaparaika sathaānaāṁtaraṇanauṁ saūcana āpayauṁ"
+  - source: "લિબિયાના એલ અજિજિયામાં ધરતી પર સૌથી વધુ તાપમાન નોંધાયું. એ વખતે છાયામાં નોંધવામાં આવેલું તાપમાન ૫૮ ડિગ્રી સેલ્સિયસ હતું."
+    expected: "laibaiyaānaā ela ajaijaiyaāmaāṁ dharataī para saauthaī vadhau taāpamaāna naoṁdhaāyauṁ. e vakhatae chaāyaāmaāṁ naoṁdhavaāmaāṁ āvaelauṁ taāpamaāna 58 ḍaigaraī saelasaiyasa hatauṁ."
+  - source: "પ્રથમ વિશ્વયુદ્ધઃ જર્મની અને ફ્રાન્સ વચ્ચે એસ્નેની લડાઈ શરૂ થઈ હતી"
+    expected: "parathama vaiśavayaudadhaḥ jaramanaī anae pharaānasa vacacae esanaenaī laḍaāī śaraū thaī hataī"
+  - source: "એન્ગ્લો-મિસ્ત્ર યુદ્ધઃ તેલ અલ કેબિરનું યુદ્ધ લડવામાં આવ્યું હતું."
+    expected: "enagalao-maisatara yaudadhaḥ taela ala kaebairanauṁ yaudadha laḍavaāmaāṁ āvayauṁ hatauṁ."
+  - source: "પુરાવા ન હતા, એ જ કારણે કેસ ચાલ્યો નહીં, પણ તેમને નજરકેદ રાખવામાં આવ્યા"
+    expected: "pauraāvaā na hataā, e ja kaāraṇae kaesa caālayao nahaīṁ, paṇa taemanae najarakaeda raākhavaāmaāṁ āvayaā"
+  - source: "સરદાર પટેલે નક્કી કર્યું હતું કે કાશ્મીર ભારતનો હિસ્સો બનશે; 91 વર્ષ પહેલાં લાહોર જેલમાં ભૂખહડતાળ દરમિયાન શહીદ થયા હતા જતીન દાસ"
+    expected: "saradaāra patạelae nakakaī karayauṁ hatauṁ kae kaāśamaīra bhaāratanao haisasao banaśae; 91 varaṣa pahaelaāṁ laāhaora jaelamaāṁ bhaūkhahaḍataāḷa daramaiyaāna śahaīda thayaā hataā jataīna daāsa"
+  - source: "કોરોના પ્રોટોકોલ વચ્ચે આજે મેડિકલ પ્રવેશ પરીક્ષા લેવાશેઃ એન્ટ્રી ટચ ફ્રી રહેશે, એડમિટ કાર્ડ બાર કોડથી ચેક થશે"
+    expected: "kaoraonaā paraotạokaola vacacae ājae maeḍaikala paravaeśa paraīkaṣaā laevaāśaeḥ enatạraī tạca pharaī rahaeśae, eḍamaitạ kaāraḍa baāra kaoḍathaī caeka thaśae"
+
+map:
+
+  characters:
+
+    'અ': 'a'
+    'આ': 'ā'
+    'ઇ': 'i'
+    'ઈ': 'ī'
+    'ઉ': 'u'
+    'ઊ': 'ū'
+    'ઋ': 'ṛ'
+    'ૠ': 'ṝ'
+    'ઌ': 'ḷ'
+    'ૡ': 'ḹ'
+
+    'ઍ': 'ê'
+    'એ': 'e'
+    'ઐ': 'ai'
+
+    'ઑ': 'ô'
+    'ઓ': 'o'
+    'ઔ': 'au'
+
+    # Gutturals
+    'ક': 'ka'
+    'ખ': 'kha'
+    'ગ': 'ga'
+    'ઘ': 'gha'
+    'ઙ': 'ṅa'
+
+    # Palatals
+    'ચ': 'ca'
+    'છ': 'cha'
+    'જ': 'ja'
+    'ઝ': 'jha'
+    'ઞ': 'ña'
+
+    # Cerebrals
+    'ટ':  'tạ'
+    'ઠ':  'ṭha'
+    'ડ':  'ḍa'
+    'ઢ':  'ḍha'
+    'ણ':  'ṇa'
+
+    # Dentals
+    'ત': 'ta'
+    'થ': 'tha'
+    'દ': 'da'
+    'ધ': 'dha'
+    'ન': 'na'
+
+    # Labials
+    'પ': 'pa'
+    'ફ': 'pha'
+    'બ': 'ba'
+    'ભ': 'bha'
+    'મ': 'ma'
+
+    # Semivowels
+    'ય': 'ya'
+    'ર': 'ra'
+    'લ': 'la'
+    'ળ': 'ḷa'
+    'વ': 'va'
+
+    # Sibilants
+    'શ': 'śa'
+    'ષ': 'ṣa'
+    'સ': 'sa'
+
+
+    # Aspirate
+    'હ': 'ha'
+
+    # Chandrabindu
+    'ઁ': 'm̐'
+
+    # Bisarga
+    'ઃ': 'ḥ'
+
+    # Anusvāra
+    'ં': 'ṁ'
+
+    # Medials # Needed for connecting constants
+
+    'ા': 'ā'
+    'િ': 'i'
+    'ી': 'ī'
+    'ુ': 'u'
+    'ૂ': 'ū'
+    'ૃ': 'ṛ'
+    'ૄ': 'ṝ'
+    '\u0AE2': 'ḷ'  #  ૢ
+    '\u0AE3': 'ḹ'  #  ૣ
+
+    'ૅ': 'ê'
+    'ૉ': 'ô'
+
+    'ે': 'e'
+    'ૈ': 'ai'
+    'ો': 'o'
+    'ૌ': 'au'
+
+    # for semivowel rule no. 5
+
+    'યઁ': 'm̐ya'
+    'રઁ': 'm̐ra'
+    'લઁ': 'm̐la'
+    'ળઁ': 'm̐ḷa'
+    'વઁ': 'm̐va'
+
+
+    'ક઼': 'qa'
+    'ખ઼': 'qa'
+    'ગ઼': 'qa'
+    'જ઼': 'za'
+    'ફ઼': 'fa'
+
+
+    # Abagraha
+    'ऽ': ':’'
+
+
+
+
+    '\u09CD': '' # Used for joining
+    '્': ''
+    '઼': ''
+    '।': '.'
+    "‍": ''# Used for joining
+
+
+    # digits
+
+    '૦': '0'
+    '૧': '1'
+    '૨': '2'
+    '૩': '3'
+    '૪': '4'
+    '૫': '5'
+    '૬': '6'
+    '૭': '7'
+    '૮': '8'
+    '૯': '9'

--- a/maps/iso-hin-Deva-Latn-15919-2001.yaml
+++ b/maps/iso-hin-Deva-Latn-15919-2001.yaml
@@ -1,0 +1,77 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:hin
+source_script: Deva
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "हम"
+    expected: "hama"
+  - source: "मीन"
+    expected: "maīna"
+  - source: "औसत"
+    expected: "ausata"
+  - source: "माँऽऽऽ!"
+    expected: "maām̐:’:’:’!"
+  - source: "माँ"
+    expected: "maām̐"
+  - source: "गंभीर मरीजों के मामले में भारत दूसरे नंबर पर"
+    expected: "gaṁbhaīra maraījaoṁ kae maāmalae maeṁ bhaārata daūsarae naṁbara para"
+  - source: "कोरोना अपडेट्स"
+    expected: "kaoraonaā apaḍaeṭasa"
+  - source: "सीडीसी चीफ का बयान अहम"
+    expected: "saīḍaīsaī caīpha kaā bayaāna ahama"
+  - source: "गूगल प्ले स्टोर पर पेटीएम की वापसी"
+    expected: "gaūgala palae saṭaora para paeṭaīema kaī vaāpasaī"
+  - source: "भारत में गैंबलिंग की इजाजत नहीं"
+    expected: "bhaārata maeṁ gaaiṁbalaiṁga kaī ijaājata nahaīṁ"
+  - source: "कोरोना वैक्सीन मुद्दे पर घिरे राष्ट्रपति; जो बाइडेन बोले- मुझे और देश को वैज्ञानिकों पर भरोसा है, डोनाल्ड ट्रम्प पर नहीं"
+    expected: "kaoraonaā vaaikasaīna maudadae para ghairae raāṣaṭarapatai; jao baāiḍaena baolae- maujhae aura daeśa kao vaaijañaānaikaoṁ para bharaosaā haai, ḍaonaālaḍa ṭaramapa para nahaīṁ"
+  - source: "गूगल की कार्रवाई पर पेटीएम ने कहा था कि ऐप को अस्थायी तौर पर प्ले-स्टोर से हटाया गया है, आपके पैसे सुरक्षित हैं"
+    expected: "gaūgala kaī kaāraravaāī para paeṭaīema nae kahaā thaā kai aipa kao asathaāyaī taaura para palae-saṭaora sae haṭaāyaā gayaā haai, āpakae paaisae saurakaṣaita haaiṁ"
+
+map:
+
+  inherit: iso-san-Deva-Latn-15919-2001

--- a/maps/iso-inc-Deva-Latn-15919-2001.yaml
+++ b/maps/iso-inc-Deva-Latn-15919-2001.yaml
@@ -1,0 +1,61 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:inc
+source_script: Deva
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+     -  Vowel hiatus, not digraph transliteration of diphthongs; as in Sanskrit pra:uga (not prauga), “yoke”;
+
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "उपमुख्यमंत्र्यांची 'मोठी' घोषणा; राज्यात केंद्राच्या कृषी व कामगार विधेयकाची अंमलबजावणी नाही"
+    expected: "upamaukhayamaṁtarayaāṁcaī 'maoṭhaī' ghaoṣaṇaā; raājayaāta kaeṁdaraācayaā kaṛṣaī va kaāmagaāra vaidhaeyakaācaī aṁmalabajaāvaṇaī naāhaī"
+  - source: "ग्वालियर बन रहा देश का नया जामताड़ा, ऑनलाइन ठगी के कई गिरोह का पर्दाफाश"
+    expected: "gavaālaiyara bana rahaā daeśa kaā nayaā jaāmataāड़ā, ônalaāina ṭhagaī kae kaī gairaoha kaā paradaāphaāśa"
+  - source: "२४ घण्टामा कोरोनाबाट ६ जनाको मृत्यु, मृतककाे संख्या ४ सय ५९ पुग्यो"
+    expected: "24 ghaṇaṭaāmaā kaoraonaābaāṭa 6 janaākao maṛtayau, maṛtakakaāe saṁkhayaā 4 saya 59 paugayao"
+
+map:
+
+  inherit: iso-san-Deva-Latn-15919-2001

--- a/maps/iso-kan-Knda-Latn-15919-2001.yaml
+++ b/maps/iso-kan-Knda-Latn-15919-2001.yaml
@@ -1,0 +1,220 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:kan
+source_script: Knda
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+
+tests:
+  - source: "ಈಗ ವೈರಲ್ ಆಗುತ್ತಿದೆ ಕಂಗನಾ ರಣಾವುತ್ ಹಳೇಯ ವಿಡಿಯೋ"
+    expected: "īga vaairala āgautataidae kaṁganaā raṇaāvauta haḷaēya vaiḍaiyaō"
+  - source: "ಸಂಕಷ್ಟ ಎದುರಾದರೆ ಬಿಎಸ್‌ವೈ ಬೆನ್ನಿಗೆ ಎಚ್‌ಡಿಕೆ ?"
+    expected: "saṁkaṣaṭa edauraādarae baiesavaai baenanaigae ecaḍaikae ?"
+  - source: "ಶಾಸಕರಿಂದಲೂ ಒತ್ತಡ?"
+    expected: "śaāsakaraiṁdalaū otataḍa?"
+  - source: "ಏಕೆಂದರೆ, ಇವರ ಹೆಸರೇ ಕೊರೊನಾ!"
+    expected: "ēkaeṁdarae, ivara haesaraē kaeūraonaā!"
+  - source: "ಕೊರೊನಾಕ್ಕಿಂತಲೂ ಮುಂಚೆಯೇ ಅವರು ಕೊರೊನಾ ಆಗಿದ್ದವರು!"
+    expected: "kaeūraonaākakaiṁtalaū mauṁcaeyaē avarau kaeūraonaā āgaidadavarau!"
+  - source: "ಕೇರಳದ ಕೊಟ್ಟಾಯಂನ ಮಹಿಳೆಯೊಬ್ಬರು ಈಗ ತಮ್ಮ ಹೆಸರು ಹೇಳಲು ಮುಜುಗರ ಪಡುವಂತಾಗಿದೆ"
+    expected: "kaēraḷada kaeūṭaṭaāyaṁna mahaiḷaeyaobabarau īga tamama haesarau haēḷalau maujaugara paḍauvaṁtaāgaidae"
+  - source: "ಬೇರೆ ಬೆಳವಣಿಗೆಗೆ ಸಾಕ್ಷಿ ಸಾಧ್ಯತೆ"
+    expected: "baērae baeḷavaṇaigaegae saākaṣai saādhayatae"
+  - source: "ಗುರು ಶನಿ ಗ್ರಹಗಳ ನಡುವೆ 3 ಜನರ ಪ್ರಯಾಣ"
+    expected: "gaurau śanai garahagaḷa naḍauvae 3 janara parayaāṇa"
+  - source: "ಕೊರೊನಾ ಬಿಕ್ಕಟ್ಟಿನ ಕಾಲದಲ್ಲಿ “ಮಿಸೆಸ್‌ ಕೊರೊನಾ’ಗೆ ಸಮಸ್ಯೆ!"
+    expected: "kaeūraonaā baikakaṭaṭaina kaāladalalai “maisaesa kaeūraonaā’gae samasayae!"
+  - source: "ಕೆಲವು ತಿಂಗಳಿಂದ ರಷ್ಯಾ ದೇಶದ ಏನಾಟೊಲಿ ಇವ್ಯಾನಿಶಿನ್‌ ಮತ್ತು ಇವಾನ್‌ ವ್ಯಾಗನರ್‌ ಹಾಗೂ ಅಮೆರಿಕಾದ ಕ್ರಿಸ್‌ ಕ್ಯಾಸಿಡಿ ಈ ಉಪಗ್ರಹದಲ್ಲಿ ವಾಸಿಸುತ್ತಿದ್ದಾರೆ"
+    expected: "kaelavau taiṁgaḷaiṁda raṣayaā daēśada ēnaāṭaeūlai ivayaānaiśaina matatau ivaāna vayaāganara haāgaū amaeraikaāda karaisa kayaāsaiḍai ī upagarahadalalai vaāsaisautataidadaārae"
+  - source: "ಹಾಂಗ್ ಕಾಂಗ್"
+    expected: "haāṁga kaāṁga"
+  - source: "೧೮೧೪೦"
+    expected: "18140"
+
+
+map:
+
+  characters:
+    'ಅ': 'a'
+    'ಆ': 'ā'
+    'ಇ': 'i'
+    'ಈ': 'ī'
+    'ಉ': 'u'
+    'ಊ': 'ū'
+    'ಋ': 'ṛ'
+    'ೠ': "ṝ"
+    'ಌ': 'ḻ'
+    'ೡ': 'ḹ'
+    'ಎ': 'e'
+    'ಏ': 'ē'
+    'ಐ': 'ai'
+
+    'ಒ': 'o'
+    'ಓ': 'ō'
+    'ಔ': 'au'
+
+    # II. Consonants (see Note 2)
+    # Gutturals
+    'ಕ': 'ka'
+    'ಖ': 'kha'
+    'ಗ': 'ga'
+    'ಘ': 'gha'
+    'ಙ': 'ṅa'
+
+    # Palatals
+    'ಚ': 'ca'
+    'ಛ': 'cha'
+    'ಜ': 'ja'
+    'ಝ': 'jha'
+    'ಞ': 'ña'
+
+    # Cerebrals
+    'ಟ': 'ṭa'
+    'ಠ': 'ṭha'
+    'ಡ': 'ḍa'
+    'ಢ': 'ḍha'
+    'ಣ': 'ṇa'
+
+    # Dentals
+    'ತ': 'ta'
+    'ಥ': 'tha'
+    'ದ': 'da'
+    'ಧ': 'dha'
+    'ನ': 'na'
+
+    # Labials
+    'ಪ': 'pa'
+    'ಫ': 'pha'
+    'ಬ': 'ba'
+    'ಭ': 'bha'
+    'ಮ': 'ma'
+
+    # Semivowels
+    'ಯ': 'ya'
+    'ರ': 'ra'
+    'ಱ': 'ṟa'
+    'ಲ': 'la'
+    'ಳ': 'ḷa'
+    'ವ': 'va'
+
+    # Sibilants
+    'ಶ': 'śa'
+    'ಷ': 'ṣa'
+    'ಸ': 'sa'
+
+
+    # Aspirate
+    'ಹ': 'ha'
+
+    'ಜ಼': 'za'
+    'ಫ಼': 'fa'
+
+    # Bisarga
+    'ಃ': 'ḥ'
+
+    'ೱ': 'ẖ'
+    'ೲ': 'ḫ'
+
+
+    # candrabindu
+    '\u0C80': 'm̐'
+    '\u0C81': 'm̐'
+
+    # Abagraha
+    'ಽ': ':’' # (apostrophe)
+
+    # Anusvāra
+    'ಂ': 'ṁ'
+
+    '಼': '' #nukta
+
+    # Medials # Needed for connecting constants
+    'ಾ': "ā"
+    'ಿ': "i"
+    'ೀ': "ī"
+    'ು': "u"
+    'ೂ': "ū"
+
+    'ೃ': "ṛ"
+    'ೄ': "ṝ"
+    ' ೢ': 'ḷ'
+    ' ೣ': 'ḹ'
+
+    'ೆ': "e"
+    'ೇ': "ē"
+    'ೈ': "ai"
+
+
+    'ೊ': 'o'
+    'ೋ': 'ō'
+    'ೌ': 'au'
+
+    '्': ''
+    '़': ''
+    '್': ''
+    "‍": '' # no need for zero with joiner
+    "‌": '' # no need for zero with non joiner ': 'ya'
+
+
+    # for semivowel rule no. 5
+    'ಯಀ': 'm̐ya'
+    'ರಀ': 'm̐ra'
+    'ಱಀ': 'm̐ṟa'
+    'ಲಀ': 'm̐la'
+    'ಳಀ': 'm̐ḷa'
+    'ವಀ': 'm̐va'
+
+    # numbers
+
+    '೧': '1'
+    '೨': '2'
+    '೩': '3'
+    '೪': '4'
+    '೫': '5'
+    '೬': '6'
+    '೭': '7'
+    '೮': '8'
+    '೯': '9'
+    '೦': '0'

--- a/maps/iso-mal-Mlym-Latn-15919-2001.yaml
+++ b/maps/iso-mal-Mlym-Latn-15919-2001.yaml
@@ -1,0 +1,281 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:mal
+source_script: Mlym
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - Malayalam anusvara final in a word shall be transliterated as m .
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+    - Pure consonant ( cillŭ form) in Malayalam script, other than r/ṟ (ർ), before a consonant, as in n:na formed with a
+      pure consonant (not the ligature nna). Medial ൕ in Malayalam text shall be treated as a pure consonant ( cillŭ
+      form).
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - When the half-nasal in Telugu script is used for modern nasalization in writing Hindi or
+    any other language, it shall be transliterated as a tilde above the transliterated vowel. In the case of the digraphs ai,
+    au, the tilde shall be attached to the second vowel
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+  - In Malayalam text, ് acts as the mātrā for ŭ when final in a word, except when it removes the inherent vowel of a single
+    consonant.
+  - The ambiguous pure consonant r/ṟ (ർ) in Malayalam script shall be transliterated into r when combined
+    with another consonant; when it is final in a word it shall be transliterated as ṟ in Malayalam language.
+
+tests:
+  - source: "സ്വപ്നയ്ക്കൊപ്പം ഹോട്ടലിൽ മന്ത്രിപുത്രൻ, ചിത്രങ്ങൾ; ൪ കോടി കമ്മിഷനിലും പങ്കുപറ്റി"
+    expected: "svapnaykkaeāppam haōṭṭalai:la mantraipautra:ṇa, caitraṅṅa:ḷa; 4 kaōṭai kammaiṣanailaum paṅkaupaṟṟai"
+  - source: "വിവാദങ്ങളിൽ മാപ്പില്ല, ആദ്യമായി ഐപിഎൽ കമന്ററിക്കില്ലാതെ മ‍ഞ്ജരേക്കര്‍; പുറത്ത് തന്നെ"
+    expected: "vaivaādaṅṅaḷai:la maāppailla, ādyamaāyai aipaie:la kamanṟaṟaikkaillaātae mañjaraēkkaraŭ; pauṟattaŭ tannae"
+  - source: "പരമാവധി ഊറ്റിയെടുത്തു; എല്ലാം കഴിഞ്ഞ് ഉപേക്ഷിച്ചു: വിങ്ങലോടെ റംസിയുടെ സഹോദരി"
+    expected: "paramaāvadhai ūṟṟaiyaeṭauttau; ellaām kaḻaiññaŭ upaēkṣaiccau: vaiṅṅalaōṭae ṟaṁsaiyauṭae sahaōdarai"
+  - source: "വഴിനീളെ രോഷം; യൂത്ത്‌ കോണ്‍ഗ്രസുകാരന്റെ  കയ്യൊടിഞ്ഞു, കൈവീശികാട്ടി ജലീൽ"
+    expected: "vaḻainaīḷae raōṣam; yaūttaŭ kaōṇaŭgrasaukaāranṟae  kayyaoṭaiññau, kaaivaīśaikaāṭṭai jalaī:la"
+  - source: "‘വികൃതിപ്പയ്യനാ’യിരുന്ന കോലി മിന്നും താരമായത് ഇന്ത്യൻ ക്രിക്കറ്റിന്റെ ഗുണം: അക്തർ"
+    expected: "‘vaikaṛtaippayyanaā’yairaunna kaōlai mainnaum taāramaāyataŭ intya:ṇa kraikkaṟṟainṟae gauṇam: aktaṟ"
+  - source: "ലോകത്തിനു വാക്സീൻ വേണമെങ്കിൽ ഈ നഗരം കനിയണം; തലയുയർത്തി ഇന്ത്യ"
+    expected: "laōkattainau vaāksaī:ṇa vaēṇamaeṅkai:la ī nagaram kanaiyaṇam; talayauyarttai intya"
+  - source: "‘അദ്ദേഹം ഒരു മകളെപ്പോലെ എന്നെ കേട്ടു’: ഗവർണറെ കണ്ട് കങ്കണ റനൗട്ട്"
+    expected: "‘addaēham orau makaḷaeppaōlae ennae kaēṭṭau’: gavarṇaṟae kaṇṭaŭ kaṅkaṇa ṟanaṭṭaŭ"
+  - source: "‘എല്ലാം ഫെയ്‌സ്ബുക്കില്‍ പറയുമെന്നു ജലീല്‍; കനത്ത സുരക്ഷയില്‍ യാത്ര, കരിങ്കൊടി"
+    expected: "‘ellaām phaeyaŭsbaukkailaŭ paṟayaumaennau jalaīlaŭ; kanatta saurakṣayailaŭ yaātra, karaiṅkaoṭai"
+  - source: "ഏറ്റവും ചെറുപ്പം ജോയി; ജയലക്ഷ്മി, ദീപ്തി, ജ്യോതി; പട്ടികയിലെ നിര ഇങ്ങനെ‌"
+    expected: "ēṟṟavaum caeṟauppam jaōyai; jayalakṣmai, daīptai, jyaōtai; paṭṭaikayailae naira iṅṅanae"
+  - source: "പരിശോധന കുറച്ച് കേരളം; കോവിഡ് ടെസ്റ്റ് പോസിറ്റിവിറ്റി നിരക്ക് എറ്റവും ഉയർന്ന്; ആശങ്ക‌"
+    expected: "paraiśaōdhana kauṟaccaŭ kaēraḷam; kaōvaid̂aŭ ṭaesṟṟaŭ paōsaiṟṟaivaiṟṟai nairakkaŭ eṟṟavaum uyarnnaŭ; āśaṅka"
+  - source: "൱"
+    expected: "100"
+
+map:
+
+  rules:
+    - pattern: (?<=)\u0D4D(?=\b) # Rule 12
+      result: 'ŭ'
+    - pattern: (?<=)\u0D02(?=\b) # Rule 3
+      result: 'm'
+    - pattern: (?<=)\u0D7C(?=\b) # Rule 13
+      result: 'ṟ'
+
+  characters:
+    'അ': 'a'
+    'ആ': 'ā'
+    'ഇ': 'i'
+    'ഈ': 'ī'
+    'ഉ': 'u'
+    'ഊ': 'ū'
+    'ഋ': "ṛ"
+    'ൠ': "ṝ"
+    'ഌ': "ḷ"
+    'ൡ': "ḹ"
+
+    'എ': 'e'
+    'ഏ': 'ē'
+    'ഐ': 'ai'
+
+    'ഒ': 'o'
+    'ഓ': 'ō'
+    'ഔ': 'au'
+
+    # Consonants
+    # Gutturals
+    'ക': 'ka'
+    'ഖ': 'kha'
+    'ഗ': 'ga'
+    'ഘ': 'gha'
+    'ങ': 'ṅa'
+
+    # Palatals
+    'ച': 'ca'
+    'ഛ': 'cha'
+    'ജ': 'ja'
+    'ഝ': 'jha'
+    'ഞ': 'ña'
+
+    # Cerebrals
+    'ട':  'ṭa'
+    'ഠ':  'ṭha'
+    'ഡ': 'd̂a'
+    'ഢ':  'ḍha'
+    'ണ':  'ṇa'
+
+    # Dentals
+    'ത': 'ta'
+    'ഥ': 'tha'
+    'ദ': 'da'
+    'ധ': 'dha'
+    'ന': 'na'
+
+    # Labials
+    'പ': 'pa'
+    'ഫ': 'pha'
+    'ബ': 'ba'
+    'ഭ': 'bha'
+    'മ': 'ma'
+
+    # Semivowels
+    'യ': 'ya'
+    'ര': 'ra'
+    'ർ': 'r'
+    'റ': 'ṟa'
+    'ല': 'la'
+    'ള': 'ḷa'
+    'ഴ': 'ḻa'
+    # Sibilants
+    'വ': 'va'
+    'ശ': 'śa'
+    'ഷ': 'ṣa'
+    'സ': 'sa'
+    'ഩ': 'ṉa'
+
+
+    # Aspirate
+    'ഹ': 'ha'
+
+    # Bisarga
+    'ഃ': 'ḥ'
+
+    # Anusvāra
+    'ം': 'ṁ'
+
+
+    # Abagraha
+    'ഽ': ':’' # (apostrophe)
+
+    # Medials # Needed for connecting constants
+
+    'ാ': 'ā'
+    'ി': 'i'
+    'ീ': 'ī'
+    'ു': 'u'
+    'ൂ': 'ū'
+    '്': 'ŭ'
+    'ൃ': "ṛ"
+    'ൄ': "ṝ"
+    '\u0D62': "ḷ"
+    '\u0D63': "ḹ"
+    'െ': "e"
+    'േ': "ē"
+    'ൈ': "ai"
+    'ൊ': 'o'
+    'ോ': 'ō'
+    'ൌ': 'au'
+
+    '्': ''
+    '़': ''
+    'ൗ': ''
+    "‍": '' # no need for zero with joiner
+    "‌": '' # no need for zero with non joiner
+
+
+    # For rule 12
+    # Gutturals
+    'ക്': 'k'
+    'ഖ്': 'kh'
+    'ഗ്': 'g'
+    'ഘ്': 'gh'
+    'ങ്': 'ṅ'
+
+    # Palatals
+    'ച്': 'c'
+    'ഛ്': 'ch'
+    'ജ്': 'j'
+    'ഝ്': 'jh'
+    'ഞ്': 'ñ'
+
+    # Cerebrals
+    'ട്':  'ṭ'
+    'ഠ്':  'ṭh'
+    'ഡ്': 'd̂'
+    'ഢ്':  'ḍh'
+    'ണ്':  'ṇ'
+
+    # Dentals
+    'ത്': 't'
+    'ഥ്': 'th'
+    'ദ്': 'd'
+    'ധ്': 'dh'
+    'ന്': 'n'
+
+    # Labials
+    'പ്': 'p'
+    'ഫ്': 'ph'
+    'ബ്': 'b'
+    'ഭ്': 'bh'
+    'മ്': 'm'
+
+    # Semivowels
+    'യ്': 'y'
+    'ര്': 'r'
+    'റ്': 'ṟ'
+    'ല്': 'l'
+    'ള്': 'ḷ'
+    'ഴ്': 'ḻ'
+    # Sibilants
+    'വ്': 'v'
+    'ശ്': 'ś'
+    'ഷ്': 'ṣ'
+    'സ്': 's'
+    'ഩ്': 'ṉ'
+
+
+    # Aspirate
+    'ഹ്': 'h'
+
+
+    # numbers
+
+    '൦': '0'
+    '൧': '1'
+    '൨': '2'
+    '൩': '3'
+    '൪': '4'
+    '൫': '5'
+    '൬': '6'
+    '൭': '7'
+    '൮': '8'
+    '൯': '9'
+    '൰': '10'
+    '൱': '100'
+    '൲': '1000'
+
+
+    # Rule 8(II)
+
+    'ൺ': ':na'
+    'ൻ': ':ṇa'
+    'ൽ': ':la'
+    'ൾ': ':ḷa'
+    'ൿ': ':ka'

--- a/maps/iso-mar-Deva-Latn-15919-2001.yaml
+++ b/maps/iso-mar-Deva-Latn-15919-2001.yaml
@@ -1,0 +1,75 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:mar
+source_script: Deva
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+     -  Vowel hiatus, not digraph transliteration of diphthongs; as in Sanskrit pra:uga (not prauga), “yoke”;
+
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "ठाणे - जिल्ह्यात बुधवारी एक हजार रुग्णांची वाढ, तर जणांच्या मृत्यूची नोंद"
+    expected: "ṭhaāṇae - jailahayaāta baudhavaāraī eka hajaāra raugaṇaāṁcaī vaāḍha, tara jaṇaāṁcayaā maṛtayaūcaī naoṁda"
+  - source: "एकता कपूर पुन्हा अडकली वादात, वेबसीरिजमधल्या 'त्या' सीनमुळे जमावाची घरावर दगडफेक"
+    expected: "ekataā kapaūra paunahaā aḍakalaī vaādaāta, vaebasaīraijamadhalayaā 'tayaā' saīnamauḷae jamaāvaācaī gharaāvara dagaḍaphaeka"
+  - source: "जाणून घ्या, बीएमसीच्या अधिकाऱ्यांनी कंगना राणौतच्या ऑफिसमधले नक्की काय- काय तोडलं"
+    expected: "jaāṇaūna ghayaā, baīemasaīcayaā adhaikaāऱyaāṁnaī kaṁganaā raāṇaautacayaā ôphaisamadhalae nakakaī kaāya- kaāya taoḍalaṁ"
+  - source: "कंगना मुंबईत दाखल होण्यापूर्वी 'मातोश्री'वरून फर्मान सुटले; प्रवक्त्यांना सक्त आदेश"
+    expected: "kaṁganaā mauṁbaīta daākhala haoṇayaāpaūravaī 'maātaośaraī'varaūna pharamaāna sauṭalae; paravakatayaāṁnaā sakata ādaeśa"
+  - source: "मराठा आरक्षणास तात्पुरती स्थगिती; सर्वोच्च न्यायालयाचा निर्णय"
+    expected: "maraāṭhaā ārakaṣaṇaāsa taātapaurataī sathagaitaī; saravaocaca nayaāyaālayaācaā nairaṇaya"
+  - source: "भारताच्या तिन्ही लशींचा पहिला टप्पा यशस्वी, वाचा कधी येणार बाजारात"
+    expected: "bhaārataācayaā tainahaī laśaīṁcaā pahailaā ṭapapaā yaśasavaī, vaācaā kadhaī yaeṇaāra baājaāraāta"
+  - source: "रुग्णवाढीमुळे खाटांची चणचण"
+    expected: "raugaṇavaāḍhaīmauḷae khaāṭaāṁcaī caṇacaṇa"
+  - source: "पीएम स्वनिधी कर्ज योजनेला मुंबईतून अल्प प्रतिसाद"
+    expected: "paīema savanaidhaī karaja yaojanaelaā mauṁbaītaūna alapa parataisaāda"
+  - source: "सांताक्रूझ-चेंबूर लिंक रोडवरील उन्नत मार्गाला स्थगिती"
+    expected: "saāṁtaākaraūjha-caeṁbaūra laiṁka raoḍavaraīla unanata maāragaālaā sathagaitaī"
+  - source: "संपादक अर्णब गोस्वामी यांच्याविरूद्ध खडक पोलिस ठाण्यात तक्रार"
+    expected: "saṁpaādaka araṇaba gaosavaāmaī yaāṁcayaāvairaūdadha khaḍaka paolaisa ṭhaāṇayaāta takaraāra"
+
+map:
+
+  inherit: iso-san-Deva-Latn-15919-2001

--- a/maps/iso-nep-Deva-Latn-15919-2001.yaml
+++ b/maps/iso-nep-Deva-Latn-15919-2001.yaml
@@ -1,0 +1,87 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:nep
+source_script: Deva
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+     -  Vowel hiatus, not digraph transliteration of diphthongs; as in Sanskrit pra:uga (not prauga), “yoke”;
+     -  Absence of aspiration, as in the Nepali plural form vid:harū (not vidharū )
+
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "लेखन"
+    expected: "laekhana"
+  - source: "मुद्रा"
+    expected: "maudaraā"
+  - source: "प्रशंसा"
+    expected: "paraśaṁsaā"
+  - source: "अंक"
+    expected: "aṁka"
+  - source: "नेकपाले स्थगित स्थायी कमिटीको बैठक भदौ गते बोलाउने भएको"
+    expected: "naekapaālae sathagaita sathaāyaī kamaiṭaīkao baaiṭhaka bhadaau gatae baolaāunae bhaekao"
+  - source: "न घर रह्यो, न परिवार"
+    expected: "na ghara rahayao, na paraivaāra"
+  - source: "ढोरपाटनमा भुजीखोला बाढीपहिरोले अभिभावक गुमाएका बालबालिकाको बिचल्ली"
+    expected: "ḍhaorapaāṭanamaā bhaujaīkhaolaā baāḍhaīpahairaolae abhaibhaāvaka gaumaāekaā baālabaālaikaākao baicalalaī"
+  - source: "सुस्मिताका काका हेमबहादुर र काकीलाई पनि पहिरोले बगायो"
+    expected: "sausamaitaākaā kaākaā haemabahaādaura ra kaākaīlaāī panai pahairaolae bagaāyao"
+  - source: "संविधान जारी भएसँगै सार्वजनिक प्रशासनमा नयाँ उत्साह आउने अपेक्षा थियो"
+    expected: "saṁvaidhaāna jaāraī bhaesam̐gaai saāravajanaika paraśaāsanamaā nayaām̐ utasaāha āunae apaekaṣaā thaiyao"
+  - source: "देशमा कोरोना संक्रमित र मृतकको संख्या हरेक दिन बढ्दो छ"
+    expected: "daeśamaā kaoraonaā saṁkaramaita ra maṛtakakao saṁkhayaā haraeka daina baḍhadao cha"
+  - source: "गाउँपालिकाका अध्यक्ष टिका गुरुङका अनुसार विष्णुदासलाई राजुले सुत्नका लागि बेलुका साथी लगेका थिए"
+    expected: "gaāum̐paālaikaākaā adhayakaṣa ṭaikaā gaurauṅakaā anausaāra vaiṣaṇaudaāsalaāī raājaulae sautanakaā laāgai baelaukaā saāthaī lagaekaā thaie"
+  - source: "यो आयोजना गाउँपालिकाको केन्द्र तेल्लोकमा पर्छ"
+    expected: "yao āyaojanaā gaāum̐paālaikaākao kaenadara taelalaokamaā paracha"
+  - source: "सुस्मिताका काका हेमबहादुर र काकीलाई पनि पहिरोले बगायो"
+    expected: "sausamaitaākaā kaākaā haemabahaādaura ra kaākaīlaāī panai pahairaolae bagaāyao"
+  - source: "चैत पहिलो साता घर आएका उनी लकडाउन भएपछि यतै रोकिए"
+    expected: "caaita pahailao saātaā ghara āekaā unaī lakaḍaāuna bhaepachai yataai raokaie"
+  - source: "काम गर्न जानेको हकमा रोजगारदाता कम्पनीको पत्रसँगै वडा र जिल्ला प्रशासनको सिफारिस अनिवार्य गरिएको छ"
+    expected: "kaāma garana jaānaekao hakamaā raojagaāradaātaā kamapanaīkao patarasam̐gaai vaḍaā ra jailalaā paraśaāsanakao saiphaāraisa anaivaāraya garaiekao cha"
+  - source: "दुःख"
+    expected: "dauḥkha"
+map:
+
+  inherit: iso-san-Deva-Latn-15919-2001

--- a/maps/iso-ori-Orya-Latn-15919-2001.yaml
+++ b/maps/iso-ori-Orya-Latn-15919-2001.yaml
@@ -1,0 +1,193 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:ori
+source_script: Deva
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Secondary ya/ẏa in Oriya scripts shall be transliterated as ya, except that it shall be
+    transliterated as ẏa after ẏ .
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+     - Unexpected use of secondary ba, as in Oriya o:ba (not oba), English “wa”.
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "ସାମ୍ପ୍ରତିକ ବିଶ୍ବ ସ୍ଥିତାବସ୍ଥାକୁ ଚାଲେଞ୍ଜ୍‌ କରୁଥିବା ଦୁଇ ମୁଖ୍ୟ ପ୍ରତିଦ୍ବନ୍ଦ୍ବୀ ହେଉଛନ୍ତି ଚୀନ୍‌ ଓ ରୁଷ୍: ଇଂଲଣ୍ଡ୍‌ ଗୁଇନ୍ଦା ଅଧିକାରୀ"
+    expected: "saāmaparataika baiśaba sathaitaābasathaākau caālaeñaja karauthaibaā daui maukhaẏa parataidabanadabaī haeuchanatai caīna o rauṣa: iṁlaṇaḍa gauinadaā adhaikaāraī"
+  - source: "ଏଣିକି ଏହି ଗାଡ଼ି ଚଳାଇଲେ ପୁଲିସ କାଟି ପାରିବ ନାହିଁ ଫାଇନ୍"
+    expected: "eṇaikai ehai gaāṛai caḷaāilae paulaisa kaāṭai paāraiba naāhaim̐ phaāina"
+  - source: "ପିସି କାରବାର ଘଟଣା, ନିଲମ୍ବନ ହେଲେ ପଞ୍ଚାୟତ ଅଧିକାରୀ"
+    expected: "paisai kaārabaāra ghaṭaṇaā, nailamabana haelae pañacaāẏata adhaikaāraī"
+  - source: "ବରିଷ୍ଠ ଓଡ଼ିଆ ଚଳଚ୍ଚିତ୍ର ଅଭିନେତା ଅଜିତ ଦାସଙ୍କ"
+    expected: "baraiṣaṭha oḍaiā caḷacacaitara abhainaetaā ajaita daāsaṅaka"
+  - source: "ସଞ୍ଚୟ କରିବାରେ କେଉଁ ରାଶି ଅଧିକ ସତର୍କ ?"
+    expected: "sañacaẏa karaibaārae kaeum̐ raāśai adhaika sataraka ?"
+  - source: "କର୍କଟ ରାଶିର ଅଧିକାରୀ ନିଜ ଜ୍ଞାତିପରିଜନଙ୍କ ପାଇଁ ଟଙ୍କା ଖର୍ଚ୍ଚ କରିବାକୁ ପସନ୍ଦ କରିଥାନ୍ତି।"
+    expected: "karakaṭa raāśaira adhaikaāraī naija jañaātaiparaijanaṅaka paāim̐ ṭaṅakaā kharacaca karaibaākau pasanada karaithaānatai."
+  - source: "ବୃଷ ରାଶିର ବ୍ୟକ୍ତିମାନେ ସ୍ବଭାବରେ କଞ୍ଜୁସ୍ କିମ୍ବା କୃପଣ ନୁହନ୍ତି"
+    expected: "baṛṣa raāśaira baẏakataimaānae sababhaābarae kañajausa kaimabaā kaṛpaṇa nauhanatai"
+  - source: "ନବନିଯୁକ୍ତ ଓଡିଶା କଂଗ୍ରେସ ପ୍ରଭାରୀ ଏ.ଚେଲ୍ଲା କୁମାରଙ୍କୁ କରୋନା"
+    expected: "nabanaiyaukata oḍaiśaā kaṁgaraesa parabhaāraī e.caelalaā kaumaāraṅakau karaonaā"
+  - source: "ଦିଲ୍ଲୀ: ଦିନ ଦ୍ବିପହରରେ ଗାଡ଼ି ଉପରକୁ ଦୁର୍ବୃତ୍ତ ଚଳାଇଲେ ୮ ରାଉଣ୍ଡ ଗୁଳି: ଚାଳକଙ୍କ ମୃତ୍ୟୁ"
+    expected: "dailalaī: daina dabaipahararae gaāṛai uparakau daurabaṛtata caḷaāilae ୮ raāuṇaḍa gauḷai: caāḷakaṅaka maṛtaẏau"
+  - source: "ବୟସରେ ଆର ପାରିକୁ ଚାଲିଗଲେ କଣ୍ଠଶିଳ୍ପୀ ଅନୁରାଧା ପୋଡୱାଲଙ୍କ ପୁଅ ଆଦିତ୍ୟ"
+    expected: "baẏasarae āra paāraikau caālaigalae kaṇaṭhaśaiḷapaī anauraādhaā paeāḍawaālaṅaka paua ādaitaẏa"
+
+map:
+
+
+  characters:
+    'ଅ': 'a'
+    'ଆ': 'ā'
+    'ଇ': 'i'
+    'ଈ': 'ī'
+    'ଉ': 'u'
+    'ଊ': 'ū'
+    'ଋ': 'ṛ'
+    'ୠ': 'ṝ'
+    'ଌ': 'ḷ'
+    'ୡ': 'ḹ'
+    'ଏ': 'e'
+    'ଐ': 'ai'
+    'ଓ': 'o'
+    'ଔ': 'au'
+
+    # II. Consonants (see Note 2)
+    # Gutturals
+    'କ': 'ka'
+    'ଖ': 'kha'
+    'ଗ': 'ga'
+    'ଘ': 'gha'
+    'ଙ': 'ṅa'
+
+    # Palatals
+    'ଚ': 'ca'
+    'ଛ': 'cha'
+    'ଜ': 'ja'
+    'ଝ': 'jha'
+    'ଞ': 'ña'
+
+    # Cerebrals
+    'ଟ':  'ṭa'
+    'ଠ':  'ṭha'
+    'ଡ':  'ḍa'
+    'ଡ଼':  'ṛa'
+    'ଢ':  'ḍha'
+    'ଢ଼':  'ṛha'
+    'ଣ':  'ṇa'
+
+    # Dentals
+    'ତ': 'ta'
+    'ଥ': 'tha'
+    'ଦ': 'da'
+    'ଧ': 'dha'
+    'ନ': 'na'
+
+    # Labials
+    'ପ': 'pa'
+    'ଫ': 'pha'
+    'ବ': 'ba'
+    'ଭ': 'bha'
+    'ମ': 'ma'
+
+    # Semivowels
+    'ଯ': 'ya'
+    'ୟ': 'ẏa'
+    'ର': 'ra'
+    'ଲ': 'la'
+    'ଳ': 'ḷa'
+    'ଵ': 'va'
+
+    # Sibilants
+    'ଶ': 'śa'
+    'ଷ': 'ṣa'
+    'ସ': 'sa'
+
+    'ୱ': 'wa'
+
+
+    # Aspirate
+    'ହ': 'ha'
+
+    # Chandrabindu
+    'ଁ': 'm̐'
+
+    # Bisarga
+    'ଃ': 'ḥ'
+
+    # Anusvāra
+    'ଂ': 'ṁ'
+
+    # Medials # Needed for connecting constants
+
+    'ା': 'ā'
+    'ି': 'i'
+    'ୀ': 'ī'
+    'ୁ': 'u'
+    'ୂ': 'ū'
+    '\u0B43': 'ṛ'
+    '\u0B44': 'ṝ'
+    '\u0B62': 'ḷ'
+    '\u0B63': 'ḹ'
+    'େ': 'e'
+    'ୈ': 'ai'
+    'ୋ': 'o'
+    'ୌ': 'au'
+
+    # Abagraha
+    'ଽ': ':’'
+
+    '्': ''
+    '୍': ''
+    '़': ''
+    '଼': ''
+    '।': '.'
+    "‍": ''# Used for joining
+    "‌": ''# Used for non joining
+
+    # for semivowel rule no. 5
+
+    'ଯଁ': 'm̐ya'
+    'ୟଁ': 'm̐ẏa'
+    'ରଁ': 'm̐ra'
+    'ଲଁ': 'm̐la'
+    'ଳଁ': 'm̐ḷa'
+    'ଵଁ': 'm̐va'

--- a/maps/iso-pli-Beng-Latn-15919-2001.yaml
+++ b/maps/iso-pli-Beng-Latn-15919-2001.yaml
@@ -1,0 +1,73 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:pli
+source_script: Beng
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "তেন সমযেন বুদ্ধো ভগৰা ৰেরঞ্জাযং ৰিহরতি নল়েরুপুচিমন্দমূলে মহতা ভিক্খুসঙ্ঘেন সদ্ধিং পঞ্চমত্তেহি ভিক্খুসতেহি"
+    expected: "taena samayaena baudadhao bhagavaā vaerañajaāyaṁ vaiharatai nala়eraupaucaimanadamaūlae mahataā bhaikakhausaṅaghaena sadadhaiṁ pañacamatataehai bhaikakhausataehai"
+  - source: "অস্সোসি খো ৰেরঞ্জো ব্রাহ্মণো"
+    expected: "asasaosai khao vaerañajao baraāhamaṇao"
+  - source: "সমণো খলু, ভো, গোতমো সক্যপুত্তো সক্যকুলা পব্বজিতো ৰেরঞ্জাযং ৰিহরতি"
+    expected: "samaṇao khalau, bhao, gaotamao sakayapautatao sakayakaulaā pababajaitao vaerañajaāyaṁ vaiharatai"
+  - source: "নল়েরুপুচিমন্দমূলে মহতা ভিক্খুসঙ্ঘেন সদ্ধিং পঞ্চমত্তেহি ভিক্খুসতেহি"
+    expected: "nala়eraupaucaimanadamaūlae mahataā bhaikakhausaṅaghaena sadadhaiṁ pañacamatataehai bhaikakhausataehai"
+  - source: "তং খো পন ভৰন্তং গোতমং এৰং কল্যাণো কিত্তিসদ্দো অব্ভুগ্গতো"
+    expected: "taṁ khao pana bhavanataṁ gaotamaṁ evaṁ kalayaāṇao kaitataisadadao ababhaugagatao"
+  - source: "সো ইমং লোকং সদেৰকং সমারকং সব্রহ্মকং সস্সমণব্রাহ্মণিং পজং সদেৰমনুস্সং সযং অভিঞ্ঞা সচ্ছিকত্ৰা পৰেদেতি"
+    expected: "sao imaṁ laokaṁ sadaevakaṁ samaārakaṁ sabarahamakaṁ sasasamaṇabaraāhamaṇaiṁ pajaṁ sadaevamanausasaṁ sayaṁ abhaiñañaā sacachaikatavaā pavaedaetai"
+  - source: "অরসরূপো সমণো গোতমো’তি, নো চ খো যং ত্ৰং সন্ধায ৰদেসী’’তি"
+    expected: "arasaraūpao samaṇao gaotamao’tai, nao ca khao yaṁ tavaṁ sanadhaāya vadaesaī’’tai"
+  - source: "অরসরূপো ভৰং গোতমো’’তি?"
+    expected: "arasaraūpao bhavaṁ gaotamao’’tai?"
+  - source: "অত্থি খ্ৰেস, ব্রাহ্মণ, পরিযাযো যেন মং পরিযাযেন সম্মা ৰদমানো ৰদেয্য"
+    expected: "atathai khavaesa, baraāhamaṇa, paraiyaāyao yaena maṁ paraiyaāyaena samamaā vadamaānao vadaeyaya"
+  - source: "অরসরূপো সমণো গোতমো’তি"
+    expected: "arasaraūpao samaṇao gaotamao’tai"
+
+map:
+  inherit: 'iso-asm-Beng-Latn-15919-2001'
+

--- a/maps/iso-pli-Deva-Latn-15919-2001.yaml
+++ b/maps/iso-pli-Deva-Latn-15919-2001.yaml
@@ -1,0 +1,74 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:pli
+source_script: Deva
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+     -  Vowel hiatus, not digraph transliteration of diphthongs; as in Sanskrit pra:uga (not prauga), “yoke”;
+     -  Absence of aspiration, as in the Nepali plural form vid:harū (not vidharū )
+
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "तेन खो पन समयेन वेसालिया अविदूरे कलन्दगामो नाम अत्थि"
+    expected: "taena khao pana samayaena vaesaālaiyaā avaidaūrae kalanadagaāmao naāma atathai"
+  - source: "तत्थ सुदिन्‍नो नाम कलन्दपुत्तो सेट्ठिपुत्तो होति"
+    expected: "tatatha saudainanao naāma kalanadapautatao saeṭaṭhaipautatao haotai"
+  - source: "अथ खो सुदिन्‍नो कलन्दपुत्तो सम्बहुलेहि"
+    expected: "atha khao saudainanao kalanadapautatao samabahaulaehai"
+  - source: "तथा चतुर्भिः पुरुषः परीक्ष्यते त्यागेन शीलेन गुणेन कर्मणा"
+    expected: "tathaā cataurabhaiḥ paurauṣaḥ paraīkaṣayatae tayaāgaena śaīlaena gauṇaena karamaṇaā"
+  - source: "अथ खो सुदिन्‍नो कलन्दपुत्तो अचिरवुट्ठिताय परिसाय येन भगवा तेनुपसङ्कमि; उपसङ्कमित्वा भगवन्तं अभिवादेत्वा एकमन्तं निसीदि"
+    expected: "atha khao saudainanao kalanadapautatao acairavauṭaṭhaitaāya paraisaāya yaena bhagavaā taenaupasaṅakamai; upasaṅakamaitavaā bhagavanataṁ abhaivaādaetavaā ekamanataṁ naisaīdai"
+  - source: "अथ खो सुदिन्‍नस्स कलन्दपुत्तस्स मातापितरो सुदिन्‍नं कलन्दपुत्तं एतदवोचुं"
+    expected: "atha khao saudainanasasa kalanadapautatasasa maātaāpaitarao saudainanaṁ kalanadapautataṁ etadavaocauṁ"
+  - source: "त्वं खोसि, तात सुदिन्‍न, अम्हाकं एकपुत्तको पियो मनापो सुखेधितो सुखपरिहतो"
+    expected: "tavaṁ khaosai, taāta saudainana, amahaākaṁ ekapautatakao paiyao manaāpao saukhaedhaitao saukhaparaihatao"
+  - source: "न त्वं, तात सुदिन्‍न, किञ्‍चि दुक्खस्स जानासि"
+    expected: "na tavaṁ, taāta saudainana, kaiñacai daukakhasasa jaānaāsai"
+  - source: "अनुञ्‍ञातोम्हि किर मातापितूहि अगारस्मा अनगारियं पब्बज्‍जाया’’ति, हट्ठो उदग्गो पाणिना गत्तानि परिपुञ्छन्तो वुट्ठासि"
+    expected: "anauñañaātaomahai kaira maātaāpaitaūhai agaārasamaā anagaāraiyaṁ pababajajaāyaā’’tai, haṭaṭhao udagagao paāṇainaā gatataānai paraipauñachanatao vauṭaṭhaāsai"
+
+map:
+
+  inherit: iso-san-Deva-Latn-15919-2001

--- a/maps/iso-pli-Sinh-Latn-15919-2001.yaml
+++ b/maps/iso-pli-Sinh-Latn-15919-2001.yaml
@@ -1,0 +1,219 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:pli
+source_script: Sinh
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - When the half-nasal in Telugu script is used for modern nasalization in writing Hindi or
+    any other language, it shall be transliterated as a tilde above the transliterated vowel. In the case of the digraphs ai,
+    au, the tilde shall be attached to the second vowel
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "තෙන සමයෙන බුද්‌ධො භගවා වෙරඤ්‌ජායං විහරති නළෙරුපුචිමන්‌දමූලෙ මහතා භික්‌ඛුසඞ්‌ඝෙන සද්‌ධිං"
+    expected: "taena samayaena baudadhao bhagavaā vaerañajaāyaṁ vaiharatai naḷaeraupaucaimanadamaūlae mahataā bhaikakhausaṅaghaena sadadhaiṁ"
+  - source: "පඤ්‌චමත්‌තෙහි භික්‌ඛුසතෙහි. අස්‌සොසි ඛො වෙරඤ්‌ජො බ්‍රාහ්‌මණො"
+    expected: "pañacamatataehai bhaikakhausataehai. asasaosai khao vaerañajao baraāhamaṇao"
+  - source: "අථ ඛො වෙරඤ්‌ජො බ්‍රාහ්‌මණො යෙන භගවා තෙනුපසඞ්‌කමි;"
+    expected: "atha khao vaerañajao baraāhamaṇao yaena bhagavaā taenaupasaṅakamai;"
+  - source: "උපසඞ්‌කමිත්‌වා භගවතා සද්‌ධිං සම්‌මොදි."
+    expected: "upasaṅakamaitavaā bhagavataā sadadhaiṁ samamaodai."
+  - source: "නිබ්‌භොගො භවං ගොතමො"
+    expected: "naibabhaogao bhavaṁ gaotamao"
+  - source: "අකිරියවාදො භවං ගොතමො"
+    expected: "akairaiyavaādao bhavaṁ gaotamao"
+  - source: "උච්‌ඡෙදවාදො භවං ගොතමො"
+    expected: "ucachaedavaādao bhavaṁ gaotamao"
+  - source: "ජෙගුච්‌ඡී භවං ගොතමො"
+    expected: "jaegaucachaī bhavaṁ gaotamao"
+  - source: "අහොසි අසල්‌ලීනං, උපට්‌ඨිතා සති අසම්‌මුට්‌ඨා‍"
+    expected: "ahaosai asalalaīnaṁ, upaṭaṭhaitaā satai asamamauṭaṭhaā"
+  - source: "අත්‌ථි ඛ්‌වෙස, බ්‍රාහ්‌මණ, පරියායො යෙන මං පරියායෙන සම්‌මා වදමානො වදෙය්‍"
+    expected: "atathai khavaesa, baraāhamaṇa, paraiyaāyao yaena maṁ paraiyaāyaena samamaā vadamaānao vadaeya"
+
+
+
+map:
+
+
+  characters:
+
+    'අ': 'a'
+    'ආ': 'ā'
+    'ඇ': 'æ'
+    'ඈ': 'ǣ'
+    'ඉ': 'i'
+    'ඊ': 'ī'
+    'උ': 'u'
+    'ඌ': 'ū'
+    'ඍ': 'ṛ'
+    'ඎ': 'ṝ'
+    'ඏ': 'ḻ'
+    'ඐ': 'ḹ'
+    'එ': 'e'
+    'ඒ': 'ē'
+    'ඓ': 'ai'
+    'ඔ': 'o'
+    'ඕ': 'ō'
+    'ඖ': 'au'
+
+    'ා': 'ā'
+    'ැ': 'æ'
+    'ෑ': 'ǣ'
+    'ි': 'i'
+    'ී': 'ī'
+    'ු': 'u'
+    'ූ': 'ū'
+    'ෘ': 'ṛ'
+    'ෲ': 'ṝ'
+    'ෟ': 'ḻ'
+    'ෳ': 'ḹ'
+    'ෙ': 'e'
+    'ේ': 'ē'
+    'ෛ': 'ai'
+    'ො': 'o'
+    'ෝ': 'ō'
+    'ෞ': 'au'
+
+
+    # II. Consonants (see Note 2)
+    # Gutturals  క ఖ గ ఘ ఙ
+    'ක': 'ka'
+    'ඛ': 'kha'
+    'ග': 'ga'
+    'ඝ': 'gha'
+    'ඞ': 'ṅa'
+    'ඟ': 'ṅga'
+
+    # Palatals చ ఛ జ ఝ ఞ
+    'ච': 'ca'
+    'ඡ': 'cha'
+    'ජ': 'ja'
+    'ඣ': 'jha'
+    'ඤ': 'ña'
+    'ඦ': 'ñja'
+
+
+    # Cerebrals ట ఠ డ ఢ ణ
+    'ට':  'ṭa'
+    'ඨ':  'ṭha'
+    'ඩ':  'ḍa'
+    'ඪ':  'ḍha'
+    'ණ':  'ṇa'
+    'ඬ':  'ṇḍa'
+
+    # Dentals త థ ద ధ న
+    'ත': 'ta'
+    'ථ': 'tha'
+    'ද': 'da'
+    'ධ': 'dha'
+    'න': 'na'
+    'ඳ': 'nda'
+
+    # Labials ప ఫ బ భ మ
+    'ප': 'pa'
+    'ඵ': 'pha'
+    'බ': 'ba'
+    'භ': 'bha'
+    'ම': 'ma'
+    'ඹ': 'mba'
+
+    # Semivowels య ర ల వ
+    'ය': 'ya'
+    'ර': 'ra'
+    'ල': 'la'
+    'ළ': 'ḷa'
+    'ව': 'va'
+
+    # Sibilants శ ష స హ
+    'ශ': 'śa'
+    'ෂ': 'ṣa'
+    'ස': 'sa'
+
+
+
+    # Aspirate
+    'හ': 'ha'
+
+    'ෆ': 'fa'
+
+    # Chandrabindu
+    'ઁ': 'm̐'
+
+    # Bisarga
+    'ඃ': 'ḥ'
+
+    # Anusvāra
+    'ං': 'ṁ'
+
+
+    # numbers
+
+    '\u0DE6': '0'
+    '\u0DE7': '1'
+    '\u0DE8': '2'
+    '\u0DE9': '3'
+    '\u0DEA': '4'
+    '\u0DEB': '5'
+    '\u0DEC': '6'
+    '\u0DED': '7'
+    '\u0DEE': '8'
+    '\u0DEF': '9'
+
+
+    # semivowel chandrabindu rule
+
+    # Semivowels య ర ల వ
+    'යઁ': 'm̐ya'
+    'රઁ': 'm̐ra'
+    'ලઁ': 'm̐la'
+    'ළઁ': 'm̐ḷa'
+    'වઁ': 'm̐va'
+
+
+
+    '\u09CD': '' # Used for joining
+    "‍": ''# Used for joining
+    "‌": ''# Used for non joining
+    "්": '' # virama
+

--- a/maps/iso-pra-Deva-Latn-15919-2001.yaml
+++ b/maps/iso-pra-Deva-Latn-15919-2001.yaml
@@ -1,0 +1,59 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:pra
+source_script: Deva
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "सृष्टिस्थितिविनाशानां शक्तिभूते सनातनि"
+    expected: "saṛṣaṭaisathaitaivainaāśaānaāṁ śakataibhaūtae sanaātanai"
+  - source: "गुणाश्रये गुणमये नारायणि नमोऽस्तु ते"
+    expected: "gauṇaāśarayae gauṇamayae naāraāyaṇai namao:’satau tae"
+  - source: "तेन समयेन बुद्धो भगवा सावत्थियं विहरति जेतवने अनाथपिण्डिकस्स आरामे"
+    expected: "taena samayaena baudadhao bhagavaā saāvatathaiyaṁ vaiharatai jaetavanae anaāthapaiṇaḍaikasasa āraāmae"
+map:
+
+  inherit: iso-san-Deva-Latn-15919-2001

--- a/maps/iso-san-Deva-Latn-15919-2001.yaml
+++ b/maps/iso-san-Deva-Latn-15919-2001.yaml
@@ -1,0 +1,216 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:san
+source_script: Deva
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+     -  Vowel hiatus, not digraph transliteration of diphthongs; as in Sanskrit pra:uga (not prauga), “yoke”;
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "पूर्णमदः पूर्णमिदं पूर्णात् पूर्ण्मुदच्यते"
+    expected: "paūraṇamadaḥ paūraṇamaidaṁ paūraṇaāta paūraṇamaudacayatae"
+  - source: "पूर्णस्य पूर्णमादाय पूर्णमेवावशिष्यते"
+    expected: "paūraṇasaya paūraṇamaādaāya paūraṇamaevaāvaśaiṣayatae"
+  - source: "यथा चतुर्भिः कनकं परीक्ष्यते निर्घषणच्छेदन तापताडनैः"
+    expected: "yathaā cataurabhaiḥ kanakaṁ paraīkaṣayatae nairaghaṣaṇacachaedana taāpataāḍanaaiḥ"
+  - source: "तथा चतुर्भिः पुरुषः परीक्ष्यते त्यागेन शीलेन गुणेन कर्मणा"
+    expected: "tathaā cataurabhaiḥ paurauṣaḥ paraīkaṣayatae tayaāgaena śaīlaena gauṇaena karamaṇaā"
+  - source: "यो न हृष्यति न द्वेष्टि न शोचति न काङ्‍क्षति"
+    expected: "yao na haṛṣayatai na davaeṣaṭai na śaocatai na kaāṅakaṣatai"
+  - source: "शुभाशुभपरित्यागी भक्तिमान्यः स मे प्रियः"
+    expected: "śaubhaāśaubhaparaitayaāgaī bhakataimaānayaḥ sa mae paraiyaḥ"
+  - source: "सत्य -सत्यमेवेश्वरो लोके सत्ये धर्मः सदाश्रितः"
+    expected: "sataya -satayamaevaeśavarao laokae satayae dharamaḥ sadaāśaraitaḥ"
+  - source: "सत्यमूलनि सर्वाणि सत्यान्नास्ति परं पदम्"
+    expected: "satayamaūlanai saravaāṇai satayaānanaāsatai paraṁ padama"
+  - source: "पिता माताग्निरात्मा च गुरुश्च भरतर्षभ"
+    expected: "paitaā maātaāganairaātamaā ca gaurauśaca bharataraṣabha"
+  - source: "पल्यालँ"
+    expected: "palayaām̐la"
+  - source: "दुसूलँ"
+    expected: "dausaūm̐la"
+
+map:
+
+  characters:
+
+    # I. Vowels and Diphthongs (see Note 1)
+
+    'अ': 'a'
+    'आ': 'ā'
+    'इ': 'i'
+    'ई': 'ī'
+    'उ': 'u'
+    'ऊ': 'ū'
+    'ऋ': 'ṛ'
+    'ॠ': 'ṝ'
+    'ऌ': 'ḷ'
+    'ॡ': 'ḹ'
+    'ए': 'e'
+    'ऐ': 'ai'
+    'ओ': 'o'
+    'औ': 'au'
+    'ऍ': 'ê'
+    'ऑ': 'ô'
+
+    # II. Consonants (see Note 2)
+    # Gutturals
+    'क': 'ka'
+    'ख': 'kha'
+    'ग': 'ga'
+    'घ': 'gha'
+    'ङ': 'ṅa'
+
+    # Palatals
+    'च': 'ca'
+    'छ': 'cha'
+    'ज': 'ja'
+    'झ': 'jha'
+    'ञ': 'ña'
+
+    # Cerebrals
+    'ट': 'ṭa'
+    'ठ': 'ṭha'
+    'ड': 'ḍa'
+    'ढ': 'ḍha'
+    'ण': 'ṇa'
+
+    # Dentals
+    'त': 'ta'
+    'थ': 'tha'
+    'द': 'da'
+    'ध': 'dha'
+    'न': 'na'
+
+    # Labials
+    'प': 'pa'
+    'फ': 'pha'
+    'ब': 'ba'
+    'भ': 'bha'
+    'म': 'ma'
+
+    # Semivowels
+    'य': 'ya'
+    'र': 'ra'
+    'ल': 'la'
+    'ळ': 'ḷa'
+    'व': 'va'
+
+    # Sibilants
+    'श': 'śa'
+    'ष': 'ṣa'
+    'स': 'sa'
+
+    # Aspirate
+    'ह': 'ha'
+
+
+    # Dotted variants
+    'क़': 'qa'
+    'ख़': 'k͟ha'
+    'ग़': 'ġa'
+    'ज़': 'za'
+    'ड़': 'ṛa'
+    'ढ़': 'ṛha'
+    'फ़': 'fa'
+
+    'ᳵ': 'ẖ'
+    'ᳶ': 'ḫ'
+
+
+    # Anusvāra
+    'ं': 'ṁ'
+
+    # Bisarga
+    'ः': 'ḥ'
+
+    # candrabindu
+    'ँ': 'm̐'
+
+    # Abagraha
+    'ऽ': ':’' # (apostrophe)
+
+
+    # Medials # Needed for connecting constants
+    'ा': "ā"
+    'ि': "i"
+    'ी': "ī"
+    'ु': "u"
+    'ू': "ū"
+    'ॢ': "ḷ"
+    'ॣ': "ḹ"
+    'ृ': "ṛ"
+    'ॄ': "ṝ"
+    'े': "e"
+    'ै': "ai"
+    'ो': "o"
+    'ौ': "au"
+    'ॉ': 'ô'
+    'ॅ': "ê"
+
+    '्': ""
+    '‍': ''# Used for joining
+
+
+    # for semivowel rule no. 5
+
+    'यँ': 'm̐ya'
+    'रँ': 'm̐ra'
+    'लँ': 'm̐la'
+    'ळँ': 'm̐ḷa'
+    'वँ': 'm̐va'
+
+
+    # digits
+
+    '०': '0'
+    '१': '1'
+    '२': '2'
+    '३': '3'
+    '४': '4'
+    '५': '5'
+    '६': '6'
+    '७': '7'
+    '८': '8'
+    '९': '9'

--- a/maps/iso-tam-Taml-Latn-15919-2001.yaml
+++ b/maps/iso-tam-Taml-Latn-15919-2001.yaml
@@ -1,0 +1,159 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:tam
+source_script: Taml
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+     - Removal of ambiguity in the limited character set option. Tamil perii:i:iya, “really big”, separating the vowels.
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - Numerals in Tamil scripts shall be converted into decimal notation on transliteration, where
+    necessary.
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "கார்த்திகேயன்"
+    expected: "kaāratataikaēyaṉa"
+  - source: "௲"
+    expected: "1000"
+  - source: "இளைஞர்களின் உறுதியான மனநிலையை பிரதிபலிக்கிறது: நீட் தேர்வில் ௮௫-௯௦ சதவீத மாணவர்கள் பங்கேற்பு - ரமேஷ் பொக்ரியால்"
+    expected: "iḷaaiñarakaḷaiṉa uṟautaiyaāṉa maṉanailaaiyaai pairataipalaikakaiṟatau: naīṭa taēravaila 85-9௦ catavaīta maāṇavarakaḷa paṅakaēṟapau - ramaēṣa paokaraiyaāla"
+  - source: "நாடாளுமன்றத்தில் 4 மசோதாக்களை எதிர்க்க காங்கிரஸ் முடிவு - ஜெயராம் ரமேஷ்"
+    expected: "naāṭaāḷaumaṉaṟatataila 4 macaōtaākakaḷaai etairakaka kaāṅakairasa mauṭaivau - jaeyaraāma ramaēṣa"
+  - source: "கர்நாடகாவில் மேலும் 9,894 பேருக்கு கொரோனா தொற்று உறுதி"
+    expected: "karanaāṭakaāvaila maēlauma 9,894 paēraukakau kaoraōṉaā taoṟaṟau uṟautai"
+  - source: "ஐதராபாத்துக்கு கைகொடுக்குமா அதிரடி?"
+    expected: "aitaraāpaātataukakau kaaikaoṭaukakaumaā atairaṭai?"
+  - source: "அமெரிக்க ஓபன் டென்னிஸ்: இறுதிப்போட்டியில் டொமினிக்-ஸ்வெரேவ்"
+    expected: "amaeraikaka ōpaṉa ṭaeṉaṉaisa: iṟautaipapaōṭaṭaiyaila ṭaomaiṉaika-savaeraēva"
+  - source: "ஐ.பி.எல். கிரிக்கெட்டில் களம் இறங்கும் அமெரிக்க வீரர்"
+    expected: "ai.pai.ela. kairaikakaeṭaṭaila kaḷama iṟaṅakauma amaeraikaka vaīrara"
+  - source: "அமெரிக்க ஓபன் டென்னிஸ்; நவோமி ஒசாகா சாம்பியன் பட்டம் வென்றார்"
+    expected: "amaeraikaka ōpaṉa ṭaeṉaṉaisa; navaōmai ocaākaā caāmapaiyaṉa paṭaṭama vaeṉaṟaāra"
+  - source: "புதிய கல்விக்கொள்கைக்கு எதிர்ப்பு: முன்னாள் துணைவேந்தர்கள் 20 பேர் பிரதமருக்கு கடிதம்"
+    expected: "pautaiya kalavaikakaoḷakaaikakau etairapapau: mauṉaṉaāḷa tauṇaaivaēnatarakaḷa 20 paēra pairatamaraukakau kaṭaitama"
+  - source: "இந்த ஆண்டு ஐ.பி.எல். கோப்பையை எந்த அணி வெல்லும்? - கெவின் பீட்டர்சன் கணிப்பு"
+    expected: "inata āṇaṭau ai.pai.ela. kaōpapaaiyaai enata aṇai vaelalauma? - kaevaiṉa paīṭaṭaracaṉa kaṇaipapau"
+  - source: "இந்திய எண்ணெய் கப்பலில் தீ: விபத்து குறித்த எச்சரிக்கையை கப்பல் அதிகாரிகள் புறக்கணித்தனர் - இலங்கை கோர்ட்டு தகவல்"
+    expected: "inataiya eṇaṇaeya kapapalaila taī: vaipatatau kauṟaitata ecacaraikakaaiyaai kapapala ataikaāraikaḷa pauṟakakaṇaitataṉara - ilaṅakaai kaōraṭaṭau takavala"
+
+map:
+
+  characters:
+    'அ': 'a'
+    'ஆ': 'ā'
+    'ா': 'ā'
+
+    'இ': 'i'
+    'ி': 'i'
+
+    'ஈ': 'ī'
+    'ீ': 'ī'
+
+    'உ': 'u'
+    'ு': 'u'
+
+    'ஊ': 'ū'
+    'ூ': 'ū'
+
+    'ெ': "e"
+    'எ': 'e'
+
+    'ே': "ē"
+    'ஏ': 'ē'
+
+    'ஐ': 'ai'
+    'ை': "ai"
+
+    'ஒ': 'o'
+    'ொ': 'o'
+
+    'ோ': 'ō'
+    'ஓ': 'ō'
+
+    'ஔ': 'au'
+    'ௌ': 'au'
+
+
+    'க': 'ka'
+    'ங': 'ṅa'
+    'ஃ': 'ḵ'
+    'ச': 'ca'
+    'ஞ': 'ña'
+    'ட': 'ṭa'
+    'ண': 'ṇa'
+    'த': 'ta'
+    'ந': 'na'
+    'ப': 'pa'
+    'ம': 'ma'
+    'ய': 'ya'
+    'ர': 'ra'
+    'ல': 'la'
+    'ள': 'ḷa'
+    'ழ': 'ḻa'
+    'வ': 'va'
+    'ற': 'ṟa'
+    'ன': 'ṉa'
+    'ஜ': 'ja'
+    'ஶ': 'śa'
+    'ஷ': 'ṣa'
+    'ஸ': 'sa'
+    'ஹ': 'ha'
+
+    # Digits
+    '௧': '1'
+    '௨': '2'
+    '௩': '3'
+    '௪': '4'
+    '௫': '5'
+    '௬': '6'
+    '௭': '7'
+    '௮': '8'
+    '௯': '9'
+    '௰': '10'
+    '௱': '100'
+    '௲': '1000'
+
+
+
+    '்' : ''
+    "‍": '' # no need for zero with joiner
+    "‌": '' # no need for zero with non joiner

--- a/maps/iso-tel-Telu-Latn-15919-2001.yaml
+++ b/maps/iso-tel-Telu-Latn-15919-2001.yaml
@@ -1,0 +1,220 @@
+---
+authority_id: iso
+id: 15919-2001
+language: iso-639-2:tel
+source_script: Telu
+destination_script: Latn
+name: "Information and documentation — Transliteration of Devanagari and related Indic scripts into Latin characters"
+url: https://www.chatranjali.fr/Scripts/Standards/ISO15919.pdf
+creation_date: 2001
+adoption_date: 2001
+description: |
+  Script conversion is often required for documents such as historical and literary texts, geographical texts (including
+  maps and atlases), bibliographies, catalogues, lists and passports (and other identification documents).
+
+  Text in Devanagari script or other Indic scripts sometimes needs to be shown in Latin script, where users, or
+  equipment that they are using, cannot read or write the text
+
+  This International Standard applies to transliteration of Devanagari, and to Indic scripts related to Devanagari,
+  independent of the period in which it is or was used.
+
+notes:
+
+  - All transliterations made using this International Standard shall be case-insensitive.
+  - Inherent a with a consonant shall always be transliterated.
+  - anusvara (including Vedic anusvara) shall be transliterated as ṁ
+  - candrabindu shall be transliterated as m̐
+  - When m̐, ṃ or ṁ are associated with a vowel, they shall be placed after the vowel. When m̐ is associated
+    with a semivowel, it shall be placed before the semivowel.
+  - Latin punctuation signs and Hindu-Arabic numerals shall remain unchanged in transliteration.
+    Indic punctuation is outside the scope of this International Standard.
+  - The Vedic accent Udatta shall be transliterated as an acute accent over the transliterated vowel, and the
+    independent Svarita as a grave accent over the transliterated vowel. In the case of the digraphs ai, au, the accent
+    shall be attached to the second vowel.
+  - |
+    A colon: before a Latin character shall be used to resolve ambiguity. Some normative cases are as
+    follows.
+     -  :’ for avagraha in modern text. (The apostrophe in modern text remains unchanged in accordance with previous rule.
+  - If a character in an Indic script is defined in such a way as to be equivalent to another character in any
+    script, where the second character has a transliteration in this International Standard, then the first character shall
+    be transliterated in the same way as the second character.
+  - When the half-nasal in Telugu script is used for modern nasalization in writing Hindi or
+    any other language, it shall be transliterated as a tilde above the transliterated vowel. In the case of the digraphs ai,
+    au, the tilde shall be attached to the second vowel
+  - Where it is desired to show the Vedic accent Anudatta, it should be transliterated as an underscore. In the case of
+    the digraphs ai, au, both Latin vowels should be underscored.
+    Where word boundaries are not shown in the original text (as happens commonly in Sanskrit) and a word ends in a
+    consonant, the transliteration should show word division by a space; but when phonological processes result in two
+    words sharing a common vowel, no attempt should be made to separate them. This will require a good knowledge
+    of the language in question.
+
+
+tests:
+  - source: "ఇప్పుడు ఇదే కోవలో టాలీవుడ్‌లో మరో మల్టీస్టారర్‌ రూపొందనుందని సినీ వర్గాల్లో వార్తలు వినిపిస్తున్నాయి"
+    expected: "ipapauḍau idaē kaōvalaō ṭaālaīvauḍalaō maraō malaṭaīsaṭaārara raūpaoṁdanauṁdanai sainaī varagaālalaō vaāratalau vainaipaisataunanaāyai"
+  - source: "అంటే ఉంటాయి, అయితే అవి చాలా పెద్దవై ఉండాల్సిన అవసరం లేదు అంటున్నారు మమ్ముట్టి"
+    expected: "aṁṭaē uṁṭaāyai, ayaitaē avai caālaā paedadavaai uṁḍaālasaina avasaraṁ laēdau aṁṭaunanaārau mamamauṭaṭai"
+  - source: "ఆ సంతోషాన్ని అభిమానులతో పంచుకున్నారు"
+    expected: "ā saṁtaōṣaānanai abhaimaānaulataō paṁcaukaunanaārau"
+  - source: "కెమెరాను అన్‌బాక్స్‌ చేసే వీడియోను సోషల్‌ మీడియాలో అభిమానులతో పంచుకున్నారు"
+    expected: "kaemaeraānau anabaākasa caēsaē vaīḍaiyaōnau saōṣala maīḍaiyaālaō abhaimaānaulataō paṁcaukaunanaārau"
+  - source: "ఇన్నాళ్లకు నిజమయింది. ఇక ఇప్పటి నుంచి దీంతో ఫొటోలు క్లిక్‌ మనిపిస్తా’’ అని ఆ వీడియోలో పేర్కొన్నారు"
+    expected: "inanaāḷalakau naijamayaiṁdai. ika ipapaṭai nauṁcai daīṁtaō phaoṭaōlau kalaika manaipaisataā’’ anai ā vaīḍaiyaōlaō paērakaonanaārau"
+  - source: "గవర్నర్‌తో కంగనా భేటీ"
+    expected: "gavaranarataō kaṁganaā bhaēṭaī"
+  - source: "శ్రియ సినిమా సెట్‌లో అడుగుపెట్టి ఆరు నెలలు కావొస్తోంది"
+    expected: "śaraiya sainaimaā saeṭalaō aḍaugaupaeṭaṭai ārau naelalau kaāvaosataōṁdai"
+  - source: "ఇప్పుడు తను కోరుకున్న కెమెరా చేతికి రావడంతో త్వరలో మమ్ముట్టి నుంచి స్టన్నింగ్‌ ఫొటోస్‌ రావడం ఖాయం అంటున్నారు ఆయన అభిమానులు"
+    expected: "ipapauḍau tanau kaōraukaunana kaemaeraā caētaikai raāvaḍaṁtaō tavaralaō mamamauṭaṭai nauṁcai saṭananaiṁga phaoṭaōsa raāvaḍaṁ khaāyaṁ aṁṭaunanaārau āyana abhaimaānaulau"
+  - source: "ఇప్పుడు ఆ వీడియో వైరల్‌ అయింది. ‘ఆ కెమెరాను కొనాలనేది చాలాకాలంగా నా కల."
+    expected: "ipapauḍau ā vaīḍaiyaō vaairala ayaiṁdai. ‘ā kaemaeraānau kaonaālanaēdai caālaākaālaṁgaā naā kala."
+  - source: "మరో వైపు ఎన్టీఆర్‌, రామ్‌చరణ్‌ కలిసి ట్రిపుల్‌ ఆర్‌ సినిమాలో నటిస్తున్నారు"
+    expected: "maraō vaaipau enaṭaīāra, raāmacaraṇa kalaisai ṭaraipaula āra sainaimaālaō naṭaisataunanaārau"
+  - source: "౪౬౨౬౯"
+    expected: "46269"
+
+map:
+
+
+  characters:
+    'అ': 'a'
+    'ఆ': 'ā'
+    'ఇ': 'i'
+    'ఈ': 'ī'
+    'ఉ': 'u'
+    'ఊ': 'ū'
+    'ఋ': 'ṛ'
+    'ౠ': 'ṝ'
+    'ఌ': 'ḻ'
+    'ౡ': 'ḹ'
+    'ఎ': 'e'
+    'ఏ': 'ē'
+    'ఐ': 'ai'
+    'ఒ': 'o'
+    'ఓ': 'ō'
+    'ఔ': 'au'
+
+
+    # II. Consonants (see Note 2)
+    # Gutturals  క ఖ గ ఘ ఙ
+    'క': 'ka'
+    'ఖ': 'kha'
+    'గ': 'ga'
+    'ఘ': 'gha'
+    'ఙ': 'ṅa'
+
+    # Palatals చ ఛ జ ఝ ఞ
+    'చ': 'ca'
+    'ఛ': 'cha'
+    'జ': 'ja'
+    'ఝ': 'jha'
+    'ఞ': 'ña'
+
+    # Cerebrals ట ఠ డ ఢ ణ
+    'ట':  'ṭa'
+    'ఠ':  'ṭha'
+    'డ':  'ḍa'
+    'ఢ':  'ḍha'
+    'ణ':  'ṇa'
+
+    # Dentals త థ ద ధ న
+    'త': 'ta'
+    'థ': 'tha'
+    'ద': 'da'
+    'ధ': 'dha'
+    'న': 'na'
+
+    # Labials ప ఫ బ భ మ
+    'ప': 'pa'
+    'ఫ': 'pha'
+    'బ': 'ba'
+    'భ': 'bha'
+    'మ': 'ma'
+
+    # Semivowels య ర ల వ
+    'య': 'ya'
+    'ర': 'ra'
+    'ఱ': 'ṛa'
+    'ల': 'la'
+    'ళ': 'ḷa'
+    'వ': 'va'
+
+    # Sibilants శ ష స హ
+    'శ': 'śa'
+    'ష': 'ṣa'
+    'స': 'sa'
+
+
+
+    # Aspirate
+    'హ': 'ha'
+
+    'ౙ': 'za'
+    'ౘ': 'ĉa'
+    'ౚ': 'ṟa'
+    '\u0C34': 'ḻa'
+
+
+    # Chandrabindu
+    'ঁ': 'm̐'
+
+    # Bisarga
+    'ః': 'ḥ'
+
+    # Anusvāra
+    'ం': 'ṁ'
+
+    # Medials # Needed for connecting constants
+
+    'ా': 'ā'
+    'ి': 'i'
+    'ీ': 'ī'
+    'ు': 'u'
+    'ూ': 'ū'
+    'ృ': 'ṛ'
+    'ౄ': "ṝ"
+    ' ౢ': "ḷ" # \u0C62
+    ' ౣ': "ḹ" # \u0C63
+    'ె': 'e'
+    'ే': 'ē'
+    'ై': 'ai'
+    'ొ': 'o'
+    'ో': 'ō'
+    'ౌ': 'au'
+    'ఁ': 'ň'
+
+
+    # Abagraha
+    'ఽ': ':’' # (apostrophe)
+
+
+    '\u0c4d': '' #verma sign for halanta
+    'ౕ	': ''
+    'ౖ	': ''
+    '्': ''
+    '़': ''
+    '\u09CD': '' # Used for joining
+    "‍": ''# Used for joining
+    "‌": ''# Used for non joining
+
+
+    'యঁ': 'm̐ya'
+    'రঁ': 'm̐ra'
+    'ఱঁ': 'm̐ṛa'
+    'లঁ': 'm̐la'
+    'ళঁ': 'm̐ḷa'
+    'వঁ': 'm̐va'
+
+
+    # numbers
+
+    '౦': '0'
+    '౧': '1'
+    '౨': '2'
+    '౩': '3'
+    '౪': '4'
+    '౫': '5'
+    '౬': '6'
+    '౭': '7'
+    '౮': '8'
+    '౯': '9'


### PR DESCRIPTION
 - added `iso-san-Deva-Latn-15919-2001`
 - added `iso-hin-Deva-Latn-15919-2001`
 - added `iso-nep-deva-latn-15919-2001`
 - added `iso-pli-deva-latn-15919-2001`
 - added `iso-pra-Deva-Latn-15919-2001`
 - added `iso-mar-Deva-Latn-15919-2001`
 - added `iso-inc-Deva-Latn-15919-2001`
 - added `iso-ben-Beng-Latn-15919-2001`
 - added `iso-asm-Beng-Latn-15919-2001`
 - added `iso-pli-Beng-Latn-15919-2001`
 - added `iso-guj-Gujr-Latn-15919-2001`
 - added `iso-ori-Orya-Latn-15919-2001`
 - added `iso-kan-Knda-Latn-15919-2001`
 - added `iso-tam-Taml-Latn-15919-2001`
 - added `iso-tel-Telu-Latn-15919-2001`
 - added `iso-mal-Mlym-Latn-15919-2001`
 - added `iso-pli-Sinh-Latn-15919-2001`