### PR TITLE
Interscript exception classes

### DIFF
--- a/lib/interscript.rb
+++ b/lib/interscript.rb
@@ -2,7 +2,14 @@ require "interscript/version"
 require "yaml"
 
 module Interscript
+  # An error caused by a lack of some map
   class MapNotFoundError < StandardError; end
+  # An error caused by a missing dependency
+  class ExternalUtilError < StandardError; end
+  # An error caused by a particular compiler
+  class SystemConversionError < StandardError; end
+  # An error caused by an incorrect map implementation
+  class MapLogicError < StandardError; end
 
   class << self
     def load_path
@@ -121,8 +128,8 @@ module Interscript
         write_path = path unless write_path
       rescue
       end
-
-      raise StandardError, "Can't find a writable path for Rababa. Consider setting a RABABA_DATA environment variable" unless write_path
+  
+      raise ExternalUtilError, "Can't find a writable path for Rababa. Consider setting a RABABA_DATA environment variable" unless write_path
 
       model_path = "#{write_path}/model-#{model_name}.onnx"
 

--- a/lib/interscript/dsl.rb
+++ b/lib/interscript/dsl.rb
@@ -67,7 +67,7 @@ module Interscript::DSL
         ruby << l
       end
     end
-    raise ArgumentError, "metadata stage isn't terminated" if md_reading
+    raise Interscript::MapLogicError, "metadata stage isn't terminated" if md_reading
     ruby, yaml = ruby.join("\n"), yaml.join("\n")
 
     obj = Interscript::DSL::Document.new(map_name)

--- a/lib/interscript/dsl/aliases.rb
+++ b/lib/interscript/dsl/aliases.rb
@@ -14,7 +14,7 @@ class Interscript::DSL::Aliases
     end
 
     unless Symbol === name
-      raise TypeError, "Alias name must be a Symbol, given #{name.class}"
+      raise Interscript::SystemConversionError, "Alias name must be a Symbol, given #{name.class}"
     end
 
     puts "def_alias(#{name.inspect}, #{thing.inspect})" if $DEBUG

--- a/lib/interscript/dsl/group.rb
+++ b/lib/interscript/dsl/group.rb
@@ -10,7 +10,7 @@ class Interscript::DSL::Group
 
   def run(stage, **kwargs)
     if stage.class != Interscript::Node::Item::Stage
-      raise TypeError, "I::Node::Item::Stage expected, got #{stage.class}"
+      raise Interscript::MapLogicError, "I::Node::Item::Stage expected, got #{stage.class}"
     end
     @node.children << Interscript::Node::Rule::Run.new(stage, **kwargs)
   end

--- a/lib/interscript/dsl/items.rb
+++ b/lib/interscript/dsl/items.rb
@@ -55,7 +55,7 @@ module Interscript::DSL::Items
     class << self
       # Select a remote map
       def [] map
-        Symbol === map or raise TypeError, "A map name must be a Symbol, not #{alias_name.class}"
+        Symbol === map or raise Interscript::MapLogicError, "A map name must be a Symbol, not #{alias_name.class}"
         Map.new(map)
       end
       alias method_missing []
@@ -68,7 +68,7 @@ module Interscript::DSL::Items
 
     # Implementation of `map.x.aliasname`
     def [] alias_name
-      Symbol === alias_name or raise TypeError, "An alias name must be a Symbol, not #{alias_name.class}"
+      Symbol === alias_name or raise Interscript::MapLogicError, "An alias name must be a Symbol, not #{alias_name.class}"
       Interscript::Node::Item::Alias.new(alias_name, map: @name)
     end
     alias method_missing []

--- a/lib/interscript/dsl/metadata.rb
+++ b/lib/interscript/dsl/metadata.rb
@@ -4,7 +4,7 @@ class Interscript::DSL::Metadata
   attr_accessor :node
 
   def initialize(yaml: false, map_name: "", library: true, &block)
-    raise ArgumentError, "Can't evaluate metadata from Ruby context" unless yaml
+    raise Interscript::MapLogicError, "Can't evaluate metadata from Ruby context" unless yaml
     @map_name = map_name
     @node = Interscript::Node::MetaData.new
     self.instance_exec(&block)

--- a/lib/interscript/node/item.rb
+++ b/lib/interscript/node/item.rb
@@ -42,7 +42,7 @@ class Interscript::Node::Item < Interscript::Node
 
   def self.try_convert(i)
     i = Interscript::Node::Item::String.new(i) if i.class == ::String
-    raise TypeError, "Wrong type #{i.class}, expected I::Node::Item" unless Interscript::Node::Item === i
+    raise Interscript::MapLogicError, "Wrong type #{i.class}, expected I::Node::Item" unless Interscript::Node::Item === i
     i
   end
 end

--- a/lib/interscript/node/item/any.rb
+++ b/lib/interscript/node/item/any.rb
@@ -10,7 +10,7 @@ class Interscript::Node::Item::Any < Interscript::Node::Item
       self.value = Interscript::Stdlib::ALIASES[data.name]
     else
       puts data.inspect
-      raise TypeError, "Wrong type #{data[0].class}, excepted Array, String or Range"
+      raise Interscript::MapLogicError, "Wrong type #{data[0].class}, excepted Array, String or Range"
     end
   end
 

--- a/lib/interscript/node/item/group.rb
+++ b/lib/interscript/node/item/group.rb
@@ -48,7 +48,7 @@ class Interscript::Node::Item::Group < Interscript::Node::Item
     end
 
     if wrong
-      raise TypeError, "An I::Node::Item::Group can't contain an #{wrong.class} item."
+      raise Interscript::MapLogicError, "An I::Node::Item::Group can't contain an #{wrong.class} item."
     end
   end
 

--- a/lib/interscript/node/rule/sub.rb
+++ b/lib/interscript/node/rule/sub.rb
@@ -184,7 +184,7 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
         node
       else
         state[:right][node.id] = true
-        state[:left][node.id - 1] or raise "Capture count doesn't match"
+        state[:left][node.id - 1] or raise Interscript::MapLogicError, "Capture count doesn't match"
       end
     when Interscript::Node::Item::CaptureGroup
       state[:left] << node

--- a/lib/interscript/stdlib.rb
+++ b/lib/interscript/stdlib.rb
@@ -226,7 +226,7 @@ class Interscript::Stdlib
     def self.secryst(output, model:)
       require "secryst" rescue nil # Try to load secryst, but don't fail hard if not possible.
       unless defined? Secryst
-        raise StandardError, "Secryst is not loaded. Please read docs/Usage_with_Secryst.adoc"
+        raise Interscript::ExternalUtilError, "Secryst is not loaded. Please read docs/Usage_with_Secryst.adoc"
       end
       Interscript.secryst_index_locations.each do |remote|
         Secryst::Provisioning.add_remote(remote)
@@ -240,7 +240,7 @@ class Interscript::Stdlib
     def self.rababa(output, config:)
       require "rababa" rescue nil # Try to load rababa, but don't fail hard if not possible.
       unless defined? Rababa
-        raise StandardError, "Rababa is not loaded. Please read docs/Usage_with_Rababa.adoc"
+        raise Interscript::ExternalUtilError, "Rababa is not loaded. Please read docs/Usage_with_Rababa.adoc"
       end
 
       config_value = Interscript.rababa_configs[config]


### PR DESCRIPTION
This implements the following exception classes:

  # An error caused by a lack of some map
  class MapNotFoundError < StandardError; end
  # An error caused by a missing dependency
  class ExternalUtilError < StandardError; end
  # An error caused by a particular compiler
  class SystemConversionError < StandardError; end
  # An error caused by an incorrect map implementation
  class MapLogicError < StandardError; end

This fixes #737