### PR TITLE
ci: fall back to published interscript-maps gem when ../maps is absent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,11 @@ gemspec
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.13"
 
-gem "interscript-maps", path: "../maps"
+if File.exist?("../maps")
+  gem "interscript-maps", path: "../maps"
+else
+  gem "interscript-maps"
+end
 
 group :secryst do
   if File.exist?("../../secryst")


### PR DESCRIPTION
## Summary
- CI rake workflow failed on every bundle command: the Gemfile hardcoded interscript-maps as a path dependency on ../maps, which is never checked out in CI (exit 13, 'The path ../maps does not exist')
- fall back to the published RubyGems interscript-maps gem when the sibling checkout is absent — the same pattern the secryst group already uses

## What this fixes vs what remains
- FIXED: bundling in CI (all jobs now install and run)
- REMAINING (pre-existing, out of scope here): 23 standardrb lint offenses on main; pycall-based specs fail in CI (PyCall.import_module("regex") — python engine unavailable on the runners)

## Test plan
- [x] bundle/lock succeeds in every matrix job
- [ ] full rake green (needs the pycall + lint debt addressed separately)
